### PR TITLE
fix 'revision is longer than canonical'

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/aws/aws-sdk-go v1.20.12
-	github.com/gardener/machine-spec v0.0.0-00000000000000-3c5d9286001512dea107bcb5b2fdefc7e38be7ff
+	github.com/gardener/machine-spec v0.5.0
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/onsi/ginkgo v1.8.0
 	github.com/onsi/gomega v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
-github.com/gardener/machine-spec v0.0.0-00000000000000-3c5d9286001512dea107bcb5b2fdefc7e38be7ff h1:p5kQBosrBPFnvsXlP6u2uC4/i3uPnO//u92Tv5Y+lTg=
-github.com/gardener/machine-spec v0.0.0-00000000000000-3c5d9286001512dea107bcb5b2fdefc7e38be7ff/go.mod h1:JFBJcmxgovWQjBGeYUlVkrqmB5K6iZl9UKWf1I9EOVo=
+github.com/gardener/machine-spec v0.5.0 h1:YbmypnjmqkHEM9xJRz4HB9SGCeoEd3fUxFoiJzGkttA=
+github.com/gardener/machine-spec v0.5.0/go.mod h1:JFBJcmxgovWQjBGeYUlVkrqmB5K6iZl9UKWf1I9EOVo=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-openapi/jsonpointer v0.0.0-20160704185906-46af16f9f7b1/go.mod h1:+35s3my2LFTysnkMfxsJBAMHj/DoqoB9knIWoYG/Vk0=
 github.com/go-openapi/jsonreference v0.0.0-20160704190145-13c6e3589ad9/go.mod h1:W3Z9FmVs9qj+KR4zFKmDPGiLdk1D9Rlm7cyMvf57TTg=


### PR DESCRIPTION
Signed-off-by: Marcin Franczyk <marcin0franczyk@gmail.com>

**What this PR does / why we need it**:
It fixes `make build`

**Which issue(s) this PR fixes**:
Fixes # No issue created, but if fixes:
```
go: github.com/gardener/machine-spec@v0.0.0-00000000000000-3c5d9286001512dea107bcb5b2fdefc7e38be7ff: invalid pseudo-version: revision is longer than canonical (3c5d92860015)
```

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
improvement developer
```
