### PR TITLE
Support Gardener credentials data keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ seqdiagram.diag
 cmi-plugin
 *coverprofile.out*
 bin/
+.idea

--- a/pkg/aws/apis/aws_provider_spec.go
+++ b/pkg/aws/apis/aws_provider_spec.go
@@ -16,9 +16,21 @@ package api
 const (
 	// V1alpha1 is the API version
 	V1alpha1 = "mcm.gardener.cloud/v1alpha1"
+
+	// AWSAccessKeyID is a constant for a key name that is part of the AWS cloud credentials.
+	AWSAccessKeyID string = "providerAccessKeyId"
+	// AWSSecretAccessKey is a constant for a key name that is part of the AWS cloud credentials.
+	AWSSecretAccessKey string = "providerSecretAccessKey"
+
+	// AWSAlternativeAccessKeyID is a constant for a key name of a secret containing the AWS credentials (access key
+	// id).
+	AWSAlternativeAccessKeyID = "accessKeyID"
+	// AWSAlternativeSecretAccessKey is a constant for a key name of a secret containing the AWS credentials (secret
+	// access key).
+	AWSAlternativeSecretAccessKey = "secretAccessKey"
 )
 
-// AWSProviderSpec is the spec to be used while parsing the calls.
+//AWSProviderSpec is the spec to be used while parsing the calls.
 type AWSProviderSpec struct {
 	// APIVersion determines the APIversion for the provider APIs
 	APIVersion string `json:"apiVersion,omitempty"`

--- a/pkg/aws/apis/validation/validation.go
+++ b/pkg/aws/apis/validation/validation.go
@@ -131,19 +131,20 @@ func validateNetworkInterfaces(networkInterfaces []awsapi.AWSNetworkInterfaceSpe
 // ValidateSecret makes sure that the supplied secrets contains the required fields
 func ValidateSecret(secret *corev1.Secret) []error {
 	var allErrs []error
+
 	if secret == nil {
 		allErrs = append(allErrs, fmt.Errorf("SecretReference is Nil"))
 	} else {
-		if "" == string(secret.Data["providerAccessKeyId"]) {
-			allErrs = append(allErrs, fmt.Errorf("Secret providerAccessKeyId is required field"))
+		if "" == string(secret.Data[awsapi.AWSAccessKeyID]) && "" == string(secret.Data[awsapi.AWSAlternativeAccessKeyID]) {
+			allErrs = append(allErrs, fmt.Errorf("secret %s or %s is required field", awsapi.AWSAccessKeyID, awsapi.AWSAlternativeAccessKeyID))
 		}
-		if "" == string(secret.Data["providerSecretAccessKey"]) {
-			allErrs = append(allErrs, fmt.Errorf("Secret providerSecretAccessKey is required field"))
+		if "" == string(secret.Data[awsapi.AWSSecretAccessKey]) && "" == string(secret.Data[awsapi.AWSAlternativeSecretAccessKey]) {
+			allErrs = append(allErrs, fmt.Errorf("secret %s or %s is required field", awsapi.AWSSecretAccessKey, awsapi.AWSAlternativeSecretAccessKey))
 		}
-
 		if "" == string(secret.Data["userData"]) {
-			allErrs = append(allErrs, fmt.Errorf("Secret userData is required field"))
+			allErrs = append(allErrs, fmt.Errorf("secret userData is required field"))
 		}
 	}
+
 	return allErrs
 }

--- a/pkg/aws/apis/validation/validation_test.go
+++ b/pkg/aws/apis/validation/validation_test.go
@@ -724,7 +724,7 @@ var _ = Describe("Validation", func() {
 				expect: expect{
 					errToHaveOccurred: true,
 					errList: []error{
-						fmt.Errorf("Secret providerAccessKeyId is required field"),
+						fmt.Errorf("secret providerAccessKeyId or accessKeyID is required field"),
 					},
 				},
 			}),
@@ -770,7 +770,7 @@ var _ = Describe("Validation", func() {
 				expect: expect{
 					errToHaveOccurred: true,
 					errList: []error{
-						fmt.Errorf("Secret providerSecretAccessKey is required field"),
+						fmt.Errorf("secret providerSecretAccessKey or secretAccessKey is required field"),
 					},
 				},
 			}),
@@ -816,7 +816,7 @@ var _ = Describe("Validation", func() {
 				expect: expect{
 					errToHaveOccurred: true,
 					errList: []error{
-						fmt.Errorf("Secret userData is required field"),
+						fmt.Errorf("secret userData is required field"),
 					},
 				},
 			}),

--- a/pkg/aws/core_test.go
+++ b/pkg/aws/core_test.go
@@ -170,7 +170,7 @@ var _ = Describe("MachineServer", func() {
 				},
 				expect: expect{
 					errToHaveOccurred: true,
-					errMessage:        "machine codes error: code = [Internal] message = [Error while validating ProviderSpec [Secret providerAccessKeyId is required field]]",
+					errMessage:        "machine codes error: code = [Internal] message = [Error while validating ProviderSpec [secret providerAccessKeyId or accessKeyID is required field]]",
 				},
 			}),
 			Entry("providerSecretAccessKey missing for provider secret", &data{
@@ -188,7 +188,7 @@ var _ = Describe("MachineServer", func() {
 				},
 				expect: expect{
 					errToHaveOccurred: true,
-					errMessage:        "machine codes error: code = [Internal] message = [Error while validating ProviderSpec [Secret providerSecretAccessKey is required field]]",
+					errMessage:        "machine codes error: code = [Internal] message = [Error while validating ProviderSpec [secret providerSecretAccessKey or secretAccessKey is required field]]",
 				},
 			}),
 			Entry("userData missing for provider secret", &data{
@@ -206,7 +206,7 @@ var _ = Describe("MachineServer", func() {
 				},
 				expect: expect{
 					errToHaveOccurred: true,
-					errMessage:        "machine codes error: code = [Internal] message = [Error while validating ProviderSpec [Secret userData is required field]]",
+					errMessage:        "machine codes error: code = [Internal] message = [Error while validating ProviderSpec [secret userData is required field]]",
 				},
 			}),
 			Entry("Validation for providerSpec fails. Missing AMI & Region.", &data{
@@ -360,7 +360,7 @@ var _ = Describe("MachineServer", func() {
 				},
 				expect: expect{
 					errToHaveOccurred: true,
-					errMessage:        "machine codes error: code = [Internal] message = [[Secret providerAccessKeyId is required field]]",
+					errMessage:        "machine codes error: code = [Internal] message = [[secret providerAccessKeyId or accessKeyID is required field]]",
 				},
 			}),
 			Entry("providerSecretAccessKey & userData missing for secret", &data{
@@ -384,7 +384,7 @@ var _ = Describe("MachineServer", func() {
 				},
 				expect: expect{
 					errToHaveOccurred: true,
-					errMessage:        "machine codes error: code = [Internal] message = [[Secret providerSecretAccessKey is required field Secret userData is required field]]",
+					errMessage:        "machine codes error: code = [Internal] message = [[secret providerSecretAccessKey or secretAccessKey is required field secret userData is required field]]",
 				},
 			}),
 			Entry("Termination of instance that doesn't exist on provider", &data{
@@ -501,7 +501,7 @@ var _ = Describe("MachineServer", func() {
 				},
 				expect: expect{
 					errToHaveOccurred: true,
-					errMessage:        "machine codes error: code = [Internal] message = [Error while validating ProviderSpec [Secret providerAccessKeyId is required field]]",
+					errMessage:        "machine codes error: code = [Internal] message = [Error while validating ProviderSpec [secret providerAccessKeyId or accessKeyID is required field]]",
 				},
 			}),
 			Entry("providerSecretAccessKey missing for secret", &data{
@@ -526,7 +526,7 @@ var _ = Describe("MachineServer", func() {
 				},
 				expect: expect{
 					errToHaveOccurred: true,
-					errMessage:        "machine codes error: code = [Internal] message = [Error while validating ProviderSpec [Secret providerSecretAccessKey is required field]]",
+					errMessage:        "machine codes error: code = [Internal] message = [Error while validating ProviderSpec [secret providerSecretAccessKey or secretAccessKey is required field]]",
 				},
 			}),
 			Entry("userData missing for secret", &data{
@@ -551,7 +551,7 @@ var _ = Describe("MachineServer", func() {
 				},
 				expect: expect{
 					errToHaveOccurred: true,
-					errMessage:        "machine codes error: code = [Internal] message = [Error while validating ProviderSpec [Secret userData is required field]]",
+					errMessage:        "machine codes error: code = [Internal] message = [Error while validating ProviderSpec [secret userData is required field]]",
 				},
 			}),
 			Entry("Machine deletion where provider-ID is missing", &data{
@@ -695,7 +695,7 @@ var _ = Describe("MachineServer", func() {
 				},
 				expect: expect{
 					errToHaveOccurred: true,
-					errMessage:        "machine codes error: code = [Internal] message = [Error while validating ProviderSpec [Secret providerAccessKeyId is required field]]",
+					errMessage:        "machine codes error: code = [Internal] message = [Error while validating ProviderSpec [secret providerAccessKeyId or accessKeyID is required field]]",
 				},
 			}),
 			Entry("providerSecretAccessKey missing for secret", &data{
@@ -713,7 +713,7 @@ var _ = Describe("MachineServer", func() {
 				},
 				expect: expect{
 					errToHaveOccurred: true,
-					errMessage:        "machine codes error: code = [Internal] message = [Error while validating ProviderSpec [Secret providerSecretAccessKey is required field]]",
+					errMessage:        "machine codes error: code = [Internal] message = [Error while validating ProviderSpec [secret providerSecretAccessKey or secretAccessKey is required field]]",
 				},
 			}),
 			Entry("userData missing for secret", &data{
@@ -731,7 +731,7 @@ var _ = Describe("MachineServer", func() {
 				},
 				expect: expect{
 					errToHaveOccurred: true,
-					errMessage:        "machine codes error: code = [Internal] message = [Error while validating ProviderSpec [Secret userData is required field]]",
+					errMessage:        "machine codes error: code = [Internal] message = [Error while validating ProviderSpec [secret userData is required field]]",
 				},
 			}),
 


### PR DESCRIPTION
/area open-source usability
/kind enhancement
/priority normal
/platform aws

**What this PR does / why we need it**:
All the secret keys used by Gardener are now also allowed as alternatives for this machine-controller-manager plugin. This helps to not make mappings for the data keys.

**Special notes for your reviewer**:
ℹ️ Similar improvement for in-tree driver: https://github.com/gardener/machine-controller-manager/pull/578/commits/0e41070979b21dae4e27fe6504bdc99f651ec3b7 (https://github.com/gardener/machine-controller-manager/pull/578)

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```feature operator
The machine class secret does now also accept the data keys `accessKeyID` and `secretAccessKey` as alternatives for today's keys.
```