### PR TITLE
Removed redundant request parameter

### DIFF
--- a/pkg/aws/core.go
+++ b/pkg/aws/core.go
@@ -140,7 +140,6 @@ func (d *Driver) CreateMachine(ctx context.Context, req *driver.CreateMachineReq
 		IamInstanceProfile: &ec2.IamInstanceProfileSpecification{
 			Name: &(providerSpec.IAM.Name),
 		},
-		SecurityGroupIds:  []*string{aws.String(providerSpec.NetworkInterfaces[0].SecurityGroupIDs[0])},
 		NetworkInterfaces: networkInterfaceSpecs,
 		TagSpecifications: []*ec2.TagSpecification{tagInstance, tagVolume},
 	}


### PR DESCRIPTION
- Network interfaces and an instance-level security groups may not be specified on the same request.
- Hence this PR fixes it by removing the redundant security groups param in VM creation request.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Minor fix that was causing in issue as security group was already being passed in the list of NICs. 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
Bugfix: Removed the redundant security groups paramater in EC2 VM creation request.
```
