### PR TITLE
Reintroduces support for multi volume support for EC2 instances

### DIFF
--- a/pkg/aws/apis/aws_provider_spec.go
+++ b/pkg/aws/apis/aws_provider_spec.go
@@ -18,9 +18,9 @@ const (
 	V1alpha1 = "mcm.gardener.cloud/v1alpha1"
 
 	// AWSAccessKeyID is a constant for a key name that is part of the AWS cloud credentials.
-	AWSAccessKeyID string = "providerAccessKeyId"
+	AWSAccessKeyID = "providerAccessKeyId"
 	// AWSSecretAccessKey is a constant for a key name that is part of the AWS cloud credentials.
-	AWSSecretAccessKey string = "providerSecretAccessKey"
+	AWSSecretAccessKey = "providerSecretAccessKey"
 
 	// AWSAlternativeAccessKeyID is a constant for a key name of a secret containing the AWS credentials (access key
 	// id).
@@ -28,6 +28,35 @@ const (
 	// AWSAlternativeSecretAccessKey is a constant for a key name of a secret containing the AWS credentials (secret
 	// access key).
 	AWSAlternativeSecretAccessKey = "secretAccessKey"
+
+	// ClusterTagPrefix is a constanst for identifying a tag containing the cluster name
+	ClusterTagPrefix = "kubernetes.io/cluster/"
+	// RoleTagPrefix is a constanst for identifying a tag containing the node role
+	RoleTagPrefix = "kubernetes.io/role/"
+
+	// VolumeTypeGP2 is the constant for volume type of GP2
+	VolumeTypeGP2 = "gp2"
+	// VolumeTypeGP3 is the constant for volume type of GP3
+	VolumeTypeGP3 = "gp3"
+	// VolumeTypeIO1 is the constant for volume type of IO1
+	VolumeTypeIO1 = "io1"
+	// VolumeTypeST1 is the constant for volume type of STR1
+	VolumeTypeST1 = "st1"
+	// VolumeTypeSC1 is the constant for volume type of SC1
+	VolumeTypeSC1 = "sc1"
+	// VolumeTypeStandard is the constant for volume type of standard
+	VolumeTypeStandard = "standard"
+
+	// DataDeviceNameFormat refers to the data device name format specified by AWS
+	// Refer - https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html
+	DataDeviceNameFormat = `^/dev/(sd[a-z]|xvd[a-c][a-z]?)$`
+	// RootDeviceName is the name used for the root device
+	RootDeviceName = "/root"
+)
+
+var (
+	// ValidVolumeTypes contains the list of valid volumes types that can be attached to a EC2 instance
+	ValidVolumeTypes = []string{VolumeTypeGP2, VolumeTypeGP3, VolumeTypeIO1, VolumeTypeST1, VolumeTypeSC1, VolumeTypeStandard}
 )
 
 //AWSProviderSpec is the spec to be used while parsing the calls.

--- a/pkg/aws/core_test.go
+++ b/pkg/aws/core_test.go
@@ -30,6 +30,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+const (
+	awsAccessKeyIDIsMissing     = "machine codes error: code = [Internal] message = [Error while validating ProviderSpec secretRef.AWSAccessKeyID: Required value: Mention atleast providerAccessKeyId or accessKeyID]"
+	awsSecretAccessKeyIsMissing = "machine codes error: code = [Internal] message = [Error while validating ProviderSpec secretRef.AWSSecretAccessKey: Required value: Mention atleast providerSecretAccessKey or secretAccessKey]"
+	regionNAMIMissing           = "machine codes error: code = [Internal] message = [Error while validating ProviderSpec [providerSpec.ami: Required value: AMI is required, providerSpec.region: Required value: Region is required]]"
+	userDataIsMissing           = "machine codes error: code = [Internal] message = [Error while validating ProviderSpec secretRef.userData: Required value: Mention userData]"
+)
+
 var _ = Describe("MachineServer", func() {
 
 	// Some initializations
@@ -170,7 +177,7 @@ var _ = Describe("MachineServer", func() {
 				},
 				expect: expect{
 					errToHaveOccurred: true,
-					errMessage:        "machine codes error: code = [Internal] message = [Error while validating ProviderSpec [secret providerAccessKeyId or accessKeyID is required field]]",
+					errMessage:        awsAccessKeyIDIsMissing,
 				},
 			}),
 			Entry("providerSecretAccessKey missing for provider secret", &data{
@@ -188,7 +195,7 @@ var _ = Describe("MachineServer", func() {
 				},
 				expect: expect{
 					errToHaveOccurred: true,
-					errMessage:        "machine codes error: code = [Internal] message = [Error while validating ProviderSpec [secret providerSecretAccessKey or secretAccessKey is required field]]",
+					errMessage:        awsSecretAccessKeyIsMissing,
 				},
 			}),
 			Entry("userData missing for provider secret", &data{
@@ -206,7 +213,7 @@ var _ = Describe("MachineServer", func() {
 				},
 				expect: expect{
 					errToHaveOccurred: true,
-					errMessage:        "machine codes error: code = [Internal] message = [Error while validating ProviderSpec [secret userData is required field]]",
+					errMessage:        userDataIsMissing,
 				},
 			}),
 			Entry("Validation for providerSpec fails. Missing AMI & Region.", &data{
@@ -219,7 +226,7 @@ var _ = Describe("MachineServer", func() {
 				},
 				expect: expect{
 					errToHaveOccurred: true,
-					errMessage:        "machine codes error: code = [Internal] message = [Error while validating ProviderSpec [AMI is required field Region is required field]]",
+					errMessage:        regionNAMIMissing,
 				},
 			}),
 			Entry("Invalid region that doesn't exist", &data{
@@ -360,7 +367,7 @@ var _ = Describe("MachineServer", func() {
 				},
 				expect: expect{
 					errToHaveOccurred: true,
-					errMessage:        "machine codes error: code = [Internal] message = [[secret providerAccessKeyId or accessKeyID is required field]]",
+					errMessage:        "machine codes error: code = [Internal] message = [Error while validating secret secretRef.AWSAccessKeyID: Required value: Mention atleast providerAccessKeyId or accessKeyID]",
 				},
 			}),
 			Entry("providerSecretAccessKey & userData missing for secret", &data{
@@ -384,7 +391,7 @@ var _ = Describe("MachineServer", func() {
 				},
 				expect: expect{
 					errToHaveOccurred: true,
-					errMessage:        "machine codes error: code = [Internal] message = [[secret providerSecretAccessKey or secretAccessKey is required field secret userData is required field]]",
+					errMessage:        "machine codes error: code = [Internal] message = [Error while validating secret [secretRef.AWSSecretAccessKey: Required value: Mention atleast providerSecretAccessKey or secretAccessKey, secretRef.userData: Required value: Mention userData]]",
 				},
 			}),
 			Entry("Termination of instance that doesn't exist on provider", &data{
@@ -501,7 +508,7 @@ var _ = Describe("MachineServer", func() {
 				},
 				expect: expect{
 					errToHaveOccurred: true,
-					errMessage:        "machine codes error: code = [Internal] message = [Error while validating ProviderSpec [secret providerAccessKeyId or accessKeyID is required field]]",
+					errMessage:        awsAccessKeyIDIsMissing,
 				},
 			}),
 			Entry("providerSecretAccessKey missing for secret", &data{
@@ -526,7 +533,7 @@ var _ = Describe("MachineServer", func() {
 				},
 				expect: expect{
 					errToHaveOccurred: true,
-					errMessage:        "machine codes error: code = [Internal] message = [Error while validating ProviderSpec [secret providerSecretAccessKey or secretAccessKey is required field]]",
+					errMessage:        awsSecretAccessKeyIsMissing,
 				},
 			}),
 			Entry("userData missing for secret", &data{
@@ -551,7 +558,7 @@ var _ = Describe("MachineServer", func() {
 				},
 				expect: expect{
 					errToHaveOccurred: true,
-					errMessage:        "machine codes error: code = [Internal] message = [Error while validating ProviderSpec [secret userData is required field]]",
+					errMessage:        userDataIsMissing,
 				},
 			}),
 			Entry("Machine deletion where provider-ID is missing", &data{
@@ -695,7 +702,7 @@ var _ = Describe("MachineServer", func() {
 				},
 				expect: expect{
 					errToHaveOccurred: true,
-					errMessage:        "machine codes error: code = [Internal] message = [Error while validating ProviderSpec [secret providerAccessKeyId or accessKeyID is required field]]",
+					errMessage:        awsAccessKeyIDIsMissing,
 				},
 			}),
 			Entry("providerSecretAccessKey missing for secret", &data{
@@ -713,7 +720,7 @@ var _ = Describe("MachineServer", func() {
 				},
 				expect: expect{
 					errToHaveOccurred: true,
-					errMessage:        "machine codes error: code = [Internal] message = [Error while validating ProviderSpec [secret providerSecretAccessKey or secretAccessKey is required field]]",
+					errMessage:        awsSecretAccessKeyIsMissing,
 				},
 			}),
 			Entry("userData missing for secret", &data{
@@ -731,7 +738,7 @@ var _ = Describe("MachineServer", func() {
 				},
 				expect: expect{
 					errToHaveOccurred: true,
-					errMessage:        "machine codes error: code = [Internal] message = [Error while validating ProviderSpec [secret userData is required field]]",
+					errMessage:        userDataIsMissing,
 				},
 			}),
 
@@ -744,7 +751,7 @@ var _ = Describe("MachineServer", func() {
 				},
 				expect: expect{
 					errToHaveOccurred: true,
-					errMessage:        "machine codes error: code = [Internal] message = [Error while validating ProviderSpec [AMI is required field Region is required field]]",
+					errMessage:        regionNAMIMissing,
 				},
 			}),
 
@@ -769,7 +776,7 @@ var _ = Describe("MachineServer", func() {
 				},
 				expect: expect{
 					errToHaveOccurred: true,
-					errMessage:        "machine codes error: code = [Internal] message = [Error while validating ProviderSpec [Tag is required of the form kubernetes.io/cluster/****]]",
+					errMessage:        "machine codes error: code = [Internal] message = [Error while validating ProviderSpec providerSpec.tags[]: Required value: Tag required of the form kubernetes.io/cluster/****]",
 				},
 			}),
 			Entry("Cloud provider returned error while describing instance", &data{


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR re-introduces the support for multi volume support for EC2 instances that is present in the in-tree version of MCM. Refer - https://github.com/gardener/machine-controller-manager/pull/397 which was missed while migrating from in-tree to OOT provider.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
Fixes regressions while supporting multiple volumes support for EC2 instances
```
```improvement user
Validation for block devices is now improved
```