### PR TITLE
Delete machine whose providerID is empty

### DIFF
--- a/pkg/aws/util.go
+++ b/pkg/aws/util.go
@@ -26,13 +26,13 @@ import (
 // awsVolumeRegMatch represents Regex Match for AWS volume.
 var awsVolumeRegMatch = regexp.MustCompile("^vol-[^/]*$")
 
-// encodeMachineID encodes a given provider-ID as per it's provider ID
-func encodeProviderID(region, providerID string) string {
-	return fmt.Sprintf("aws:///%s/%s", region, providerID)
+// encodeInstanceID encodes a given instanceID as per it's providerID
+func encodeInstanceID(region, instanceID string) string {
+	return fmt.Sprintf("aws:///%s/%s", region, instanceID)
 }
 
-// decodeRegionAndProviderID extracts region and provider ID
-func decodeRegionAndProviderID(id string) (string, string, error) {
+// decodeRegionAndInstanceID extracts region and instanceID
+func decodeRegionAndInstanceID(id string) (string, string, error) {
 	splitProviderID := strings.Split(id, "/")
 	if len(splitProviderID) < 2 {
 		err := fmt.Errorf("Unable to decode provider-ID")

--- a/pkg/mockclient/mockclient.go
+++ b/pkg/mockclient/mockclient.go
@@ -131,6 +131,12 @@ func (ms *MockEC2Client) DescribeInstances(input *ec2.DescribeInstancesInput) (*
 	found := false
 	instanceList := make([]*ec2.Instance, 0)
 
+	for _, filter := range input.Filters {
+		if *filter.Values[0] == "kubernetes.io/cluster/"+ReturnErrorAtDescribeInstances {
+			return nil, fmt.Errorf("Cloud provider returned error")
+		}
+	}
+
 	if len(input.InstanceIds) > 0 {
 		if *input.InstanceIds[0] == ReturnEmptyListAtDescribeInstances {
 			return &ec2.DescribeInstancesOutput{
@@ -156,10 +162,6 @@ func (ms *MockEC2Client) DescribeInstances(input *ec2.DescribeInstancesInput) (*
 			return nil, fmt.Errorf("Couldn't find any instance matching requirement")
 		}
 	} else {
-
-		if *input.Filters[0].Values[0] == "kubernetes.io/cluster/"+ReturnErrorAtDescribeInstances {
-			return nil, fmt.Errorf("Cloud provider returned error")
-		}
 
 		// Target all instances
 		for _, instance := range *ms.FakeInstances {


### PR DESCRIPTION
**What this PR does / why we need it**:
Cherrypick of https://github.com/gardener/machine-controller-manager-provider-aws/pull/26 on rel-v0.4

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Allow deletion of machine whose providerID is empty.
```

