### PR TITLE
Add capacity reservation support

### DIFF
--- a/kubernetes/machine-class.yaml
+++ b/kubernetes/machine-class.yaml
@@ -42,6 +42,9 @@ providerSpec:
 secretRef: # Secret pointing to a secret which contains the provider secret and cloudconfig
   namespace: default  # Namespace
   name: test-secret # Name of the secret
+# capacityReservation: # Optional - allows targeting of an AWS Capacity reservation or an AWS Resource Group containing reservations. Use either a reservation id or group arn - but not both.
+#   capacityReservationId: "cr-05c28b843c05acc11"
+#   capacityReservationResourceGroupArn: "arn:aws:resource-groups:us-west-1:123456789012:group/my-cr-group"
 # credentialsSecretRef: # Optional - Kubernetes secret containing only provider secrets (in this case the Secret in the secretRef does not need them)
 #   name: "test-secret-credentials" # Name of the secret
 #   namespace: "default" # Namespace of secret

--- a/kubernetes/machine-class.yaml
+++ b/kubernetes/machine-class.yaml
@@ -24,6 +24,9 @@ providerSpec:
         volumeType: gp2 # Type of the root block device
         encrypted: true
         deleteOnTermination: true
+#  capacityReservation: # Optional - allows targeting of an AWS Capacity reservation or an AWS Resource Group containing reservations. Only one needs to be specified.
+#   capacityReservationId: "cr-05c28b843c05acc11"
+#   capacityReservationResourceGroupArn: "arn:aws:resource-groups:us-west-1:123456789012:group/my-cr-group"
   iam:
     name: iam-name # Name of the AWS Identity and Access Management
   keyName: key-value-pair-name # EC2 keypair used to access ec2 machine
@@ -42,9 +45,6 @@ providerSpec:
 secretRef: # Secret pointing to a secret which contains the provider secret and cloudconfig
   namespace: default  # Namespace
   name: test-secret # Name of the secret
-# capacityReservation: # Optional - allows targeting of an AWS Capacity reservation or an AWS Resource Group containing reservations. Only one needs to be specified.
-#   capacityReservationId: "cr-05c28b843c05acc11"
-#   capacityReservationResourceGroupArn: "arn:aws:resource-groups:us-west-1:123456789012:group/my-cr-group"
 # credentialsSecretRef: # Optional - Kubernetes secret containing only provider secrets (in this case the Secret in the secretRef does not need them)
 #   name: "test-secret-credentials" # Name of the secret
 #   namespace: "default" # Namespace of secret

--- a/kubernetes/machine-class.yaml
+++ b/kubernetes/machine-class.yaml
@@ -42,7 +42,7 @@ providerSpec:
 secretRef: # Secret pointing to a secret which contains the provider secret and cloudconfig
   namespace: default  # Namespace
   name: test-secret # Name of the secret
-# capacityReservation: # Optional - allows targeting of an AWS Capacity reservation or an AWS Resource Group containing reservations. Use either a reservation id or group arn - but not both.
+# capacityReservation: # Optional - allows targeting of an AWS Capacity reservation or an AWS Resource Group containing reservations. Only one needs to be specified.
 #   capacityReservationId: "cr-05c28b843c05acc11"
 #   capacityReservationResourceGroupArn: "arn:aws:resource-groups:us-west-1:123456789012:group/my-cr-group"
 # credentialsSecretRef: # Optional - Kubernetes secret containing only provider secrets (in this case the Secret in the secretRef does not need them)

--- a/pkg/aws/apis/aws_provider_spec.go
+++ b/pkg/aws/apis/aws_provider_spec.go
@@ -70,6 +70,9 @@ type AWSProviderSpec struct {
 	// BlockDevices is the list of block devices to be mapped to the instances
 	BlockDevices []AWSBlockDeviceMappingSpec `json:"blockDevices,omitempty"`
 
+	// CapacityReservationTarget is an optional field that allows assigning of machines to an AWS Capacity Reservation
+	CapacityReservationTarget *AWSCapacityReservationTargetSpec `json:"capacityReservation,omitempty"`
+
 	// EbsOptimized specifies that the EBS is optimized
 	EbsOptimized bool `json:"ebsOptimized,omitempty"`
 
@@ -123,6 +126,17 @@ type AWSBlockDeviceMappingSpec struct {
 	// we ignore any machine store volumes specified in the block device mapping
 	// for the AMI.
 	VirtualName string `json:"virtualName,omitempty"`
+}
+
+// AWSCapacityReservationTargetSpec allows to target an AWS Capacity Reservation directly or
+// indirectly using an AWS Resource Group
+type AWSCapacityReservationTargetSpec struct {
+
+	// The ID of the Capacity Reservation in which to run the instance.
+	CapacityReservationId *string `json:"capacityReservationId,omitempty"`
+
+	// The ARN of the Capacity Reservation resource group in which to run the instance.
+	CapacityReservationResourceGroupArn *string `json:"capacityReservationResourceGroupArn,omitempty"`
 }
 
 // AWSEbsBlockDeviceSpec describes a block device for an EBS volume.

--- a/pkg/aws/apis/validation/validation.go
+++ b/pkg/aws/apis/validation/validation.go
@@ -57,6 +57,7 @@ func ValidateAWSProviderSpec(spec *awsapi.AWSProviderSpec, secret *corev1.Secret
 	}
 
 	allErrs = append(allErrs, validateBlockDevices(spec.BlockDevices, fldPath.Child("blockDevices"))...)
+	allErrs = append(allErrs, validateCapacityReservations(spec.CapacityReservationTarget, fldPath.Child("capacityReservation"))...)
 	allErrs = append(allErrs, validateNetworkInterfaces(spec.NetworkInterfaces, fldPath.Child("networkInterfaces"))...)
 	allErrs = append(allErrs, ValidateSecret(secret, field.NewPath("secretRef"))...)
 	allErrs = append(allErrs, validateSpecTags(spec.Tags, fldPath.Child("tags"))...)
@@ -138,6 +139,20 @@ func validateBlockDevices(blockDevices []awsapi.AWSBlockDeviceMappingSpec, fldPa
 	for device, number := range deviceNames {
 		if number > 1 {
 			allErrs = append(allErrs, field.Required(fldPath, fmt.Sprintf("Device name '%s' duplicated %d times, DeviceName must be unique", device, number)))
+		}
+	}
+
+	return allErrs
+}
+
+func validateCapacityReservations(capacityReservation *awsapi.AWSCapacityReservationTargetSpec, fldPath *field.Path) field.ErrorList {
+	var (
+		allErrs = field.ErrorList{}
+	)
+
+	if capacityReservation != nil {
+		if capacityReservation.CapacityReservationId != nil && capacityReservation.CapacityReservationResourceGroupArn != nil {
+			allErrs = append(allErrs, field.Required(fldPath, "capacityReservationResourceGroupArn or capacityReservationId are optional but only one should be used"))
 		}
 	}
 

--- a/pkg/aws/core.go
+++ b/pkg/aws/core.go
@@ -143,6 +143,26 @@ func (d *Driver) CreateMachine(ctx context.Context, req *driver.CreateMachineReq
 		TagSpecifications: []*ec2.TagSpecification{tagInstance, tagVolume},
 	}
 
+	// Set the AWS Capacity Reservation target. Using an 'open' preference means that if the reservation is not found, then
+	// instances are launched with regular on-demand capacity.
+	if providerSpec.CapacityReservationTarget != nil {
+		if providerSpec.CapacityReservationTarget.CapacityReservationResourceGroupArn != nil {
+			inputConfig.CapacityReservationSpecification = &ec2.CapacityReservationSpecification{
+				CapacityReservationPreference: aws.String("open"),
+				CapacityReservationTarget: &ec2.CapacityReservationTarget{
+					CapacityReservationResourceGroupArn: providerSpec.CapacityReservationTarget.CapacityReservationResourceGroupArn,
+				},
+			}
+		} else if providerSpec.CapacityReservationTarget.CapacityReservationId != nil {
+			inputConfig.CapacityReservationSpecification = &ec2.CapacityReservationSpecification{
+				CapacityReservationPreference: aws.String("open"),
+				CapacityReservationTarget: &ec2.CapacityReservationTarget{
+					CapacityReservationId: providerSpec.CapacityReservationTarget.CapacityReservationId,
+				},
+			}
+		}
+	}
+
 	// Set spot price if it has been set
 	if providerSpec.SpotPrice != nil {
 		inputConfig.InstanceMarketOptions = &ec2.InstanceMarketOptionsRequest{

--- a/pkg/aws/core_test.go
+++ b/pkg/aws/core_test.go
@@ -151,7 +151,7 @@ var _ = Describe("MachineServer", func() {
 					errToHaveOccurred: false,
 				},
 			}),
-			Entry("Machine creation request for capacity reservations", &data{
+			Entry("Machine creation request for capacity reservations with capacityReservationId", &data{
 				action: action{
 					machineRequest: &driver.CreateMachineRequest{
 						Machine:      newMachine(-1),
@@ -167,7 +167,7 @@ var _ = Describe("MachineServer", func() {
 					errToHaveOccurred: false,
 				},
 			}),
-			Entry("Machine creation request for an AWS Capacity Reservation Group", &data{
+			Entry("Machine creation request for an AWS Capacity Reservation Group with capacityReservationResourceGroupArn", &data{
 				action: action{
 					machineRequest: &driver.CreateMachineRequest{
 						Machine:      newMachine(-1),

--- a/pkg/aws/core_test.go
+++ b/pkg/aws/core_test.go
@@ -151,6 +151,19 @@ var _ = Describe("MachineServer", func() {
 					errToHaveOccurred: false,
 				},
 			}),
+			Entry("Machine creation request for capacity reservations fails if more than one type given", &data{
+				action: action{
+					machineRequest: &driver.CreateMachineRequest{
+						Machine:      newMachine(-1),
+						MachineClass: newMachineClass([]byte("{\"ami\":\"ami-123456789\",\"blockDevices\":[{\"ebs\":{\"volumeSize\":50,\"volumeType\":\"gp2\"}}],\"iam\":{\"name\":\"test-iam\"},\"keyName\":\"test-ssh-publickey\",\"machineType\":\"m4.large\",\"networkInterfaces\":[{\"securityGroupIDs\":[\"sg-00002132323\"],\"subnetID\":\"subnet-123456\"}],\"region\":\"eu-west-1\",\"capacityReservation\":{\"capacityReservationId\":\"cr-05c28b843c05abcde\",\"capacityReservationResourceGroupArn\":\"arn:aws:resource-groups:us-west-1:123456789012:group/my-test-cr-group\"},\"tags\":{\"kubernetes.io/cluster/shoot--test\":\"1\",\"kubernetes.io/role/test\":\"1\"}}")),
+						Secret:       providerSecret,
+					},
+				},
+				expect: expect{
+					errToHaveOccurred: true,
+					errMessage: "machine codes error: code = [Internal] message = [Error while validating ProviderSpec providerSpec.capacityReservation: Required value: Either capacityReservationResourceGroupArn or capacityReservationId needs to be specified - but not both.]",
+				},
+			}),
 			Entry("Machine creation request for capacity reservations with capacityReservationId", &data{
 				action: action{
 					machineRequest: &driver.CreateMachineRequest{

--- a/pkg/aws/core_test.go
+++ b/pkg/aws/core_test.go
@@ -151,6 +151,38 @@ var _ = Describe("MachineServer", func() {
 					errToHaveOccurred: false,
 				},
 			}),
+			Entry("Machine creation request for capacity reservations", &data{
+				action: action{
+					machineRequest: &driver.CreateMachineRequest{
+						Machine:      newMachine(-1),
+						MachineClass: newMachineClass([]byte("{\"ami\":\"ami-123456789\",\"blockDevices\":[{\"ebs\":{\"volumeSize\":50,\"volumeType\":\"gp2\"}}],\"iam\":{\"name\":\"test-iam\"},\"keyName\":\"test-ssh-publickey\",\"machineType\":\"m4.large\",\"networkInterfaces\":[{\"securityGroupIDs\":[\"sg-00002132323\"],\"subnetID\":\"subnet-123456\"}],\"region\":\"eu-west-1\",\"capacityReservation\":{\"capacityReservationId\":\"cr-05c28b843c05abcde\"},\"tags\":{\"kubernetes.io/cluster/shoot--test\":\"1\",\"kubernetes.io/role/test\":\"1\"}}")),
+						Secret:       providerSecret,
+					},
+				},
+				expect: expect{
+					machineResponse: &driver.CreateMachineResponse{
+						ProviderID: "aws:///eu-west-1/i-0123456789-0",
+						NodeName:   "ip-0",
+					},
+					errToHaveOccurred: false,
+				},
+			}),
+			Entry("Machine creation request for an AWS Capacity Reservation Group", &data{
+				action: action{
+					machineRequest: &driver.CreateMachineRequest{
+						Machine:      newMachine(-1),
+						MachineClass: newMachineClass([]byte("{\"ami\":\"ami-123456789\",\"blockDevices\":[{\"ebs\":{\"volumeSize\":50,\"volumeType\":\"gp2\"}}],\"iam\":{\"name\":\"test-iam\"},\"keyName\":\"test-ssh-publickey\",\"machineType\":\"m4.large\",\"networkInterfaces\":[{\"securityGroupIDs\":[\"sg-00002132323\"],\"subnetID\":\"subnet-123456\"}],\"region\":\"eu-west-1\",\"capacityReservation\":{\"capacityReservationResourceGroupArn\":\"arn:aws:resource-groups:us-west-1:123456789012:group/my-test-cr-group\"},\"tags\":{\"kubernetes.io/cluster/shoot--test\":\"1\",\"kubernetes.io/role/test\":\"1\"}}")),
+						Secret:       providerSecret,
+					},
+				},
+				expect: expect{
+					machineResponse: &driver.CreateMachineResponse{
+						ProviderID: "aws:///eu-west-1/i-0123456789-0",
+						NodeName:   "ip-0",
+					},
+					errToHaveOccurred: false,
+				},
+			}),
 			Entry("Unmarshalling for provider spec fails", &data{
 				action: action{
 					machineRequest: &driver.CreateMachineRequest{


### PR DESCRIPTION

**What this PR does / why we need it**:

This PR allows machines to target an [AWS Resource Group containing Capacity Reservations](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/capacity-reservations-using.html#create-cr-group).

Sometimes AWS is unable to create new instances due to a temporary shortage of capacity in an AZ. AWS Capacity Reservations minimise the risk of stalling deployments; especially ones that use a large maxSurge (which creates more instances than you're currently running).

The default reservation target type is `open` so you can create the reservation group ahead of time without any reservations in it. If machines are created and can't match any reservations then they're created using On-Demand capacity (like the usual way).

Typically, you'd create an AWS Reservation Group ahead of time with capacity reservations inside it; normally you'd create a reservation of `replicas + maxSurge` instances for a particular platform, instance type and AZ. Any instances already running will immediately make use of the reservation but you will then have a buffer to guarantee a rolling deployment.

Targeting a reservation group is preferred because it is AZ agnostic just like Machine Classes are. So it doesn't make much sense to want to target a capacity reservation directly (instead of a group) but the option is included in this PR just in case. 

**Special notes for your reviewer**:

- I wasn't sure if I needed to do anything with migration.go as I as adding new fields so any existing classes wouldn't have them defined, any advice would be appreciated!

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Support for targeting an AWS Resource Group containing capacity reservations - https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/capacity-reservations-using.html#create-cr-group
```
