### PR TITLE
Added a provider check for the machine class in all the driver methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ cmi-plugin
 *coverprofile.out*
 bin/
 .idea
+/dev

--- a/kubernetes/machine-class.yaml
+++ b/kubernetes/machine-class.yaml
@@ -9,6 +9,7 @@ kind: MachineClass
 metadata:
   name: test-mc
   namespace: default # Namespace where the controller would watch
+provider: AWS
 providerSpec:
   ami: ami-123456 # Amazon machine image name goes here
   blockDevices:

--- a/pkg/aws/aws_suite_test.go
+++ b/pkg/aws/aws_suite_test.go
@@ -70,5 +70,15 @@ func newMachineClass(providerSpec []byte) *v1alpha1.MachineClass {
 		ProviderSpec: runtime.RawExtension{
 			Raw: providerSpec,
 		},
+		Provider: ProviderAWS,
+	}
+}
+
+func newMachineClassWithProvider(providerSpec []byte, provider string) *v1alpha1.MachineClass {
+	return &v1alpha1.MachineClass{
+		ProviderSpec: runtime.RawExtension{
+			Raw: providerSpec,
+		},
+		Provider: provider,
 	}
 }

--- a/pkg/aws/core.go
+++ b/pkg/aws/core.go
@@ -62,6 +62,12 @@ func (d *Driver) CreateMachine(ctx context.Context, req *driver.CreateMachineReq
 		machineClass = req.MachineClass
 	)
 
+	// Check if the MachineClass is for the supported cloud provider
+	if req.MachineClass.Provider != ProviderAWS {
+		err := fmt.Errorf("Requested for Provider '%s', we only support '%s'", req.MachineClass.Provider, ProviderAWS)
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
 	// Log messages to track request
 	klog.V(3).Infof("Machine creation request has been recieved for %q", req.Machine.Name)
 
@@ -177,6 +183,13 @@ func (d *Driver) DeleteMachine(ctx context.Context, req *driver.DeleteMachineReq
 		err    error
 		secret = req.Secret
 	)
+
+	// Check if the MachineClass is for the supported cloud provider
+	if req.MachineClass.Provider != ProviderAWS {
+		err := fmt.Errorf("Requested for Provider '%s', we only support '%s'", req.MachineClass.Provider, ProviderAWS)
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
 	// Log messages to track delete request
 	klog.V(3).Infof("Machine deletion request has been recieved for %q", req.Machine.Name)
 	defer klog.V(3).Infof("Machine deletion request has been processed for %q", req.Machine.Name)
@@ -240,6 +253,12 @@ func (d *Driver) GetMachineStatus(ctx context.Context, req *driver.GetMachineSta
 		machineClass = req.MachineClass
 	)
 
+	// Check if the MachineClass is for the supported cloud provider
+	if req.MachineClass.Provider != ProviderAWS {
+		err := fmt.Errorf("Requested for Provider '%s', we only support '%s'", req.MachineClass.Provider, ProviderAWS)
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
 	// Log messages to track start and end of request
 	klog.V(3).Infof("Get request has been recieved for %q", req.Machine.Name)
 
@@ -279,6 +298,12 @@ func (d *Driver) ListMachines(ctx context.Context, req *driver.ListMachinesReque
 		machineClass = req.MachineClass
 		secret       = req.Secret
 	)
+
+	// Check if the MachineClass is for the supported cloud provider
+	if req.MachineClass.Provider != ProviderAWS {
+		err := fmt.Errorf("Requested for Provider '%s', we only support '%s'", req.MachineClass.Provider, ProviderAWS)
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
 
 	// Log messages to track start and end of request
 	klog.V(3).Infof("List machines request has been recieved for %q", machineClass.Name)

--- a/pkg/aws/core_test.go
+++ b/pkg/aws/core_test.go
@@ -103,6 +103,19 @@ var _ = Describe("MachineServer", func() {
 					errToHaveOccurred: false,
 				},
 			}),
+			Entry("Simple Machine Creation Request with missing provider in MachineClass", &data{
+				action: action{
+					machineRequest: &driver.CreateMachineRequest{
+						Machine:      newMachine(-1),
+						MachineClass: newMachineClassWithProvider(providerSpec, "azure"),
+						Secret:       providerSecret,
+					},
+				},
+				expect: expect{
+					errToHaveOccurred: true,
+					errMessage:        "machine codes error: code = [InvalidArgument] message = [Requested for Provider 'azure', we only support 'AWS']",
+				},
+			}),
 			Entry("Machine creation request with volume type io1", &data{
 				action: action{
 					machineRequest: &driver.CreateMachineRequest{
@@ -348,6 +361,26 @@ var _ = Describe("MachineServer", func() {
 					errToHaveOccurred:     false,
 				},
 			}),
+			Entry("Simple Machine Delete Request with wrong provider in MachineClass", &data{
+				setup: setup{
+					createMachineRequest: &driver.CreateMachineRequest{
+						Machine:      newMachine(0),
+						MachineClass: newMachineClass(providerSpec),
+						Secret:       providerSecret,
+					},
+				},
+				action: action{
+					deleteMachineRequest: &driver.DeleteMachineRequest{
+						Machine:      newMachine(0),
+						MachineClass: newMachineClassWithProvider(providerSpec, "azure"),
+						Secret:       providerSecret,
+					},
+				},
+				expect: expect{
+					errToHaveOccurred: true,
+					errMessage:        "machine codes error: code = [InvalidArgument] message = [Requested for Provider 'azure', we only support 'AWS']",
+				},
+			}),
 			Entry("providerAccessKeyId missing for secret", &data{
 				setup: setup{
 					createMachineRequest: &driver.CreateMachineRequest{
@@ -539,6 +572,26 @@ var _ = Describe("MachineServer", func() {
 				},
 				expect: expect{},
 			}),
+			Entry("Simple Machine Get Request with unsupported provider in MachineClass", &data{
+				setup: setup{
+					createMachineRequest: &driver.CreateMachineRequest{
+						Machine:      newMachine(0),
+						MachineClass: newMachineClass(providerSpec),
+						Secret:       providerSecret,
+					},
+				},
+				action: action{
+					getMachineRequest: &driver.GetMachineStatusRequest{
+						Machine:      newMachine(0),
+						MachineClass: newMachineClassWithProvider(providerSpec, "azure"),
+						Secret:       providerSecret,
+					},
+				},
+				expect: expect{
+					errToHaveOccurred: true,
+					errMessage:        "machine codes error: code = [InvalidArgument] message = [Requested for Provider 'azure', we only support 'AWS']",
+				},
+			}),
 			Entry("providerAccessKeyId missing for secret", &data{
 				setup: setup{
 					createMachineRequest: &driver.CreateMachineRequest{
@@ -725,6 +778,20 @@ var _ = Describe("MachineServer", func() {
 							"aws:///eu-west-1/i-0123456789-2": "machine-2",
 						},
 					},
+				},
+			}),
+
+			Entry("List Machine Request with unsupported provider in MachineClass", &data{
+				setup: setup{},
+				action: action{
+					listMachineRequest: &driver.ListMachinesRequest{
+						MachineClass: newMachineClassWithProvider(providerSpec, "azure"),
+						Secret:       providerSecret,
+					},
+				},
+				expect: expect{
+					errToHaveOccurred: true,
+					errMessage:        "machine codes error: code = [InvalidArgument] message = [Requested for Provider 'azure', we only support 'AWS']",
 				},
 			}),
 			Entry("Unexpected end of JSON input", &data{
@@ -1136,7 +1203,9 @@ var _ = Describe("MachineServer", func() {
 								},
 							},
 						},
-						MachineClass: &v1alpha1.MachineClass{},
+						MachineClass: &v1alpha1.MachineClass{
+							Provider: ProviderAWS,
+						},
 						ClassSpec: &v1alpha1.ClassSpec{
 							//APIGroup: "",
 							Kind: AWSMachineClassKind,


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces checks to verify the supported provider for the machine class in the scope of driver operations

**Which issue(s) this PR fixes**:
Fixes [#599](https://github.com/gardener/machine-controller-manager/issues/599)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
