### PR TITLE
Fixes linting issues

### DIFF
--- a/pkg/aws/apis/aws_provider_spec.go
+++ b/pkg/aws/apis/aws_provider_spec.go
@@ -133,7 +133,7 @@ type AWSBlockDeviceMappingSpec struct {
 type AWSCapacityReservationTargetSpec struct {
 
 	// The ID of the Capacity Reservation in which to run the instance.
-	CapacityReservationId *string `json:"capacityReservationId,omitempty"`
+	CapacityReservationID *string `json:"capacityReservationId,omitempty"`
 
 	// The ARN of the Capacity Reservation resource group in which to run the instance.
 	CapacityReservationResourceGroupArn *string `json:"capacityReservationResourceGroupArn,omitempty"`

--- a/pkg/aws/apis/validation/validation.go
+++ b/pkg/aws/apis/validation/validation.go
@@ -151,7 +151,7 @@ func validateCapacityReservations(capacityReservation *awsapi.AWSCapacityReserva
 	)
 
 	if capacityReservation != nil {
-		if capacityReservation.CapacityReservationId != nil && capacityReservation.CapacityReservationResourceGroupArn != nil {
+		if capacityReservation.CapacityReservationID != nil && capacityReservation.CapacityReservationResourceGroupArn != nil {
 			allErrs = append(allErrs, field.Required(fldPath, "capacityReservationResourceGroupArn or capacityReservationId are optional but only one should be used"))
 		}
 	}

--- a/pkg/aws/core.go
+++ b/pkg/aws/core.go
@@ -162,11 +162,11 @@ func (d *Driver) CreateMachine(ctx context.Context, req *driver.CreateMachineReq
 					CapacityReservationResourceGroupArn: providerSpec.CapacityReservationTarget.CapacityReservationResourceGroupArn,
 				},
 			}
-		} else if providerSpec.CapacityReservationTarget.CapacityReservationId != nil {
+		} else if providerSpec.CapacityReservationTarget.CapacityReservationID != nil {
 			inputConfig.CapacityReservationSpecification = &ec2.CapacityReservationSpecification{
 				CapacityReservationPreference: aws.String("open"),
 				CapacityReservationTarget: &ec2.CapacityReservationTarget{
-					CapacityReservationId: providerSpec.CapacityReservationTarget.CapacityReservationId,
+					CapacityReservationId: providerSpec.CapacityReservationTarget.CapacityReservationID,
 				},
 			}
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes linting issues that were missed by https://github.com/gardener/machine-controller-manager-provider-aws/pull/29. This change retains the [lowerCase](https://github.com/gardener/machine-controller-manager-provider-aws/pull/33/files#diff-d30d0813f949736a1f919d711ad36e6c923f8199b135fcefd2fb0125ad10208aR136) in the actual spec definition and only updates the golang `struct{}` fields. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
