### PR TITLE
Enable using IAM.ARN

### DIFF
--- a/.ci/test
+++ b/.ci/test
@@ -49,9 +49,9 @@ if [[ "${SOURCE_PATH}" != *"src/github.com/gardener/machine-controller-manager-p
 fi
 
 # Install Ginkgo (test framework) to be able to execute the tests.
-echo "Fetching Ginkgo frawework"
+echo "Fetching Ginkgo framework"
 GO111MODULE=off go get -u github.com/onsi/ginkgo/ginkgo
-echo "Successfully fetched Ginkgo frawework"
+echo "Successfully fetched Ginkgo framework"
 
 ##############################################################################
 

--- a/kubernetes/machine-class.yaml
+++ b/kubernetes/machine-class.yaml
@@ -26,10 +26,11 @@ providerSpec:
         encrypted: true
         deleteOnTermination: true
 #  capacityReservation: # Optional - allows targeting of an AWS Capacity reservation or an AWS Resource Group containing reservations. Only one needs to be specified.
-#   capacityReservationId: "cr-05c28b843c05acc11"
-#   capacityReservationResourceGroupArn: "arn:aws:resource-groups:us-west-1:123456789012:group/my-cr-group"
-  iam:
-    name: iam-name # Name of the AWS Identity and Access Management
+#  capacityReservationId: "cr-05c28b843c05acc11"
+#  capacityReservationResourceGroupArn: "arn:aws:resource-groups:us-west-1:123456789012:group/my-cr-group"
+  iam: # either <name> or <arn> must be specified
+    name: iam-name # Name of the AWS instance profile that shall be used for the machines
+#   arn: arn # ARN of the AWS instance profile that shall be used for the machines
   keyName: key-value-pair-name # EC2 keypair used to access ec2 machine
   machineType: t2.large # Type of ec2 machine
   networkInterfaces:

--- a/pkg/aws/apis/validation/validation.go
+++ b/pkg/aws/apis/validation/validation.go
@@ -49,8 +49,8 @@ func ValidateAWSProviderSpec(spec *awsapi.AWSProviderSpec, secret *corev1.Secret
 	if "" == spec.MachineType {
 		allErrs = append(allErrs, field.Required(fldPath.Child("machineType"), "MachineType is required"))
 	}
-	if "" == spec.IAM.Name {
-		allErrs = append(allErrs, field.Required(fldPath.Child("iam.name"), "IAM Name is required"))
+	if ("" == spec.IAM.Name && "" == spec.IAM.ARN) || ("" != spec.IAM.Name && "" != spec.IAM.ARN) {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("iam"), spec.IAM, "either IAM Name or ARN must be set"))
 	}
 	if "" == spec.KeyName {
 		allErrs = append(allErrs, field.Required(fldPath.Child("keyName"), "KeyName is required"))

--- a/pkg/aws/core.go
+++ b/pkg/aws/core.go
@@ -136,6 +136,12 @@ func (d *Driver) CreateMachine(ctx context.Context, req *driver.CreateMachineReq
 	}
 
 	// Specify the details of the machine that you want to create.
+	iam := &ec2.IamInstanceProfileSpecification{}
+	if len(providerSpec.IAM.Name) > 0 {
+		iam.Name = &providerSpec.IAM.Name
+	} else if len(providerSpec.IAM.ARN) > 0 {
+		iam.Arn = &providerSpec.IAM.ARN
+	}
 
 	inputConfig := ec2.RunInstancesInput{
 		BlockDeviceMappings: blkDeviceMappings,
@@ -145,11 +151,9 @@ func (d *Driver) CreateMachine(ctx context.Context, req *driver.CreateMachineReq
 		MaxCount:            aws.Int64(1),
 		UserData:            &UserDataEnc,
 		KeyName:             aws.String(providerSpec.KeyName),
-		IamInstanceProfile: &ec2.IamInstanceProfileSpecification{
-			Name: &(providerSpec.IAM.Name),
-		},
-		NetworkInterfaces: networkInterfaceSpecs,
-		TagSpecifications: []*ec2.TagSpecification{tagInstance, tagVolume},
+		IamInstanceProfile:  iam,
+		NetworkInterfaces:   networkInterfaceSpecs,
+		TagSpecifications:   []*ec2.TagSpecification{tagInstance, tagVolume},
 	}
 
 	// Set the AWS Capacity Reservation target. Using an 'open' preference means that if the reservation is not found, then

--- a/pkg/aws/core_test.go
+++ b/pkg/aws/core_test.go
@@ -120,6 +120,22 @@ var _ = Describe("MachineServer", func() {
 					errMessage:        "machine codes error: code = [InvalidArgument] message = [Requested for Provider 'azure', we only support 'AWS']",
 				},
 			}),
+			Entry("Machine creation request with IAM ARN", &data{
+				action: action{
+					machineRequest: &driver.CreateMachineRequest{
+						Machine:      newMachine(-1, nil),
+						MachineClass: newMachineClass([]byte("{\"ami\":\"ami-123456789\",\"blockDevices\":[{\"ebs\":{\"volumeSize\":50,\"volumeType\":\"gp2\"}}],\"iam\":{\"arn\":\"some-arn\"},\"keyName\":\"test-ssh-publickey\",\"machineType\":\"m4.large\",\"networkInterfaces\":[{\"securityGroupIDs\":[\"sg-00002132323\"],\"subnetID\":\"subnet-123456\"}],\"region\":\"eu-west-1\",\"tags\":{\"kubernetes.io/cluster/shoot--test\":\"1\",\"kubernetes.io/role/test\":\"1\"}}")),
+						Secret:       providerSecret,
+					},
+				},
+				expect: expect{
+					machineResponse: &driver.CreateMachineResponse{
+						ProviderID: "aws:///eu-west-1/i-0123456789-0",
+						NodeName:   "ip-0",
+					},
+					errToHaveOccurred: false,
+				},
+			}),
 			Entry("Machine creation request with volume type io1", &data{
 				action: action{
 					machineRequest: &driver.CreateMachineRequest{


### PR DESCRIPTION
**What this PR does / why we need it**:
The `IAM.ARN` field was not usable even if it was in the API. This PR fixes this.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```feature operator
It's now possible to properly use the `IAM.ARN` field in the `MachineClass` specification. Earlier, it was only possible to use `IAM.Name`.
```
