### PR TITLE
go version for steps in pipeline upgraded

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -17,12 +17,12 @@ machine-controller-manager-provider-aws:
     steps_template: &steps_anchor
       steps:
         check:
-          image: 'golang:1.13.5'
+          image: 'golang:1.16.6'
         build:
-          image: 'golang:1.13.5'
+          image: 'golang:1.16.6'
           output_dir: 'binary'
         test:
-          image: 'golang:1.13.5'
+          image: 'golang:1.16.6'
     version_template: &version_anchor
       version:
         inject_effective_version: true


### PR DESCRIPTION
**What this PR does / why we need it**:
upgrades pipeline steps to use go version 1.16.6
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
