### PR TITLE
Updates test step of pipeline to use testmachinery base-step image

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -22,7 +22,7 @@ machine-controller-manager-provider-aws:
           image: 'golang:1.16.6'
           output_dir: 'binary'
         test:
-          image: 'golang:1.16.6'
+          image: 'eu.gcr.io/gardener-project/gardener/testmachinery/base-step:stable'
     version_template: &version_anchor
       version:
         inject_effective_version: true


### PR DESCRIPTION
**What this PR does / why we need it**:
tools like /cc/utils/cli.py will now be available in the container running the test step. `cli.py` can be used to access secret server.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
