### PR TITLE
Machine object deletion will proceed if backing VM not found

### DIFF
--- a/pkg/aws/core_test.go
+++ b/pkg/aws/core_test.go
@@ -691,7 +691,7 @@ var _ = Describe("MachineServer", func() {
 					errMessage:        awsSecretAccessKeyNUserDataAreMissing,
 				},
 			}),
-			Entry("Termination of instance that doesn't exist on provider", &data{
+			Entry("Termination of instance that doesn't exist on provider but machine obj has providerID", &data{
 				setup: setup{},
 				action: action{
 					deleteMachineRequest: &driver.DeleteMachineRequest{
@@ -702,11 +702,10 @@ var _ = Describe("MachineServer", func() {
 				},
 				expect: expect{
 					deleteMachineResponse: &driver.DeleteMachineResponse{},
-					errToHaveOccurred:     true,
-					errMessage:            "machine codes error: code = [Internal] message = [Couldn't find instance with given instance-ID i-0123456789-0]",
+					errToHaveOccurred:     false,
 				},
 			}),
-			Entry("Termination of instance that doesn't exist on provider", &data{
+			Entry("Another case for Termination of instance that doesn't exist on provider but machine obj has providerID", &data{
 				setup: setup{
 					createMachineRequest: &driver.CreateMachineRequest{
 						Machine:      newMachine(-1, nil),
@@ -717,16 +716,15 @@ var _ = Describe("MachineServer", func() {
 				action: action{
 					deleteMachineRequest: &driver.DeleteMachineRequest{
 						Machine:      newMachine(0, nil),
-						MachineClass: newMachineClass([]byte("{\"ami\":\"" + mockclient.SetInstanceID + "\",\"blockDevices\":[{\"ebs\":{\"volumeSize\":50,\"volumeType\":\"gp2\"}}],\"iam\":{\"name\":\"test-iam\"},\"keyName\":\"" + mockclient.FailQueryAtTerminateInstances + "\",\"machineType\":\"m4.large\",\"networkInterfaces\":[{\"securityGroupIDs\":[\"sg-00002132323\"],\"subnetID\":\"subnet-123456\"}],\"region\":\"eu-west-1\",\"tags\":{\"kubernetes.io/cluster/shoot--test\":\"1\",\"kubernetes.io/role/test\":\"1\"}}")),
+						MachineClass: newMachineClass(providerSpec),
 						Secret:       providerSecret,
 					},
 				},
 				expect: expect{
-					errToHaveOccurred: true,
-					errMessage:        "machine codes error: code = [Internal] message = [Couldn't find instance with given instance-ID i-0123456789-0]",
+					errToHaveOccurred: false,
 				},
 			}),
-			Entry("Termination of machine without any backing instance", &data{
+			Entry("Termination of machine obj without providerID and backing instance", &data{
 				setup: setup{},
 				action: action{
 					deleteMachineRequest: &driver.DeleteMachineRequest{

--- a/pkg/aws/core_util.go
+++ b/pkg/aws/core_util.go
@@ -246,6 +246,11 @@ func terminateInstance(req *driver.DeleteMachineRequest, svc ec2iface.EC2API, ma
 
 	_, err := svc.TerminateInstances(input)
 	if err != nil {
+		// if InvalidInstanceID.NotFound error from AWS, then assume VM is terminated
+		if strings.Contains(err.Error(), ec2.UnsuccessfulInstanceCreditSpecificationErrorCodeInvalidInstanceIdNotFound) {
+			return nil
+		}
+
 		klog.Errorf("VM %q for Machine %q couldn't be terminated: %s",
 			req.Machine.Spec.ProviderID,
 			req.Machine.Name,

--- a/pkg/mockclient/mockclient.go
+++ b/pkg/mockclient/mockclient.go
@@ -163,7 +163,7 @@ func (ms *MockEC2Client) DescribeInstances(input *ec2.DescribeInstancesInput) (*
 			}
 		}
 		if !found {
-			return nil, fmt.Errorf("Couldn't find any instance matching requirement")
+			return nil, fmt.Errorf("InvalidInstanceID.NotFound: The instance IDs do not exist")
 		}
 	} else {
 
@@ -191,12 +191,6 @@ func (ms *MockEC2Client) TerminateInstances(input *ec2.TerminateInstancesInput) 
 			ec2.UnsuccessfulInstanceCreditSpecificationErrorCodeInvalidInstanceIdMalformed, "",
 			fmt.Errorf("Termination of instance errorred out"),
 		)
-	} else if *input.InstanceIds[0] == InstanceDoesntExistError {
-		// If instance with instance ID doesn't exist
-		return nil, awserr.New(
-			ec2.UnsuccessfulInstanceCreditSpecificationErrorCodeInvalidInstanceIdNotFound, "",
-			fmt.Errorf("Instance with instance-ID doesn't exist"),
-		)
 	}
 
 	var desiredInstance ec2.Instance
@@ -217,7 +211,7 @@ func (ms *MockEC2Client) TerminateInstances(input *ec2.TerminateInstancesInput) 
 	ms.FakeInstances = &newInstanceList
 
 	if !found {
-		return nil, fmt.Errorf("Couldn't find instance with given instance-ID %s", *input.InstanceIds[0])
+		return nil, fmt.Errorf("InvalidInstanceID.NotFound: The instance IDs do not exist")
 	}
 
 	return &ec2.TerminateInstancesOutput{
@@ -239,13 +233,6 @@ func (ms *MockEC2Client) StopInstances(input *ec2.StopInstancesInput) (*ec2.Stop
 
 	if *input.InstanceIds[0] == InstanceStopError {
 		return nil, fmt.Errorf("Stopping of instance errored out")
-	} else if *input.InstanceIds[0] == InstanceDoesntExistError {
-		// If instance with instance ID doesn't exist
-		return nil, awserr.New(
-			ec2.UnsuccessfulInstanceCreditSpecificationErrorCodeInvalidInstanceIdMalformed,
-			"Instance with instance-ID doesn't exist",
-			fmt.Errorf("Instance with instance-ID doesn't exist"),
-		)
 	} else if *input.DryRun {
 		// If it is a dry run
 		return nil, awserr.New(
@@ -270,7 +257,7 @@ func (ms *MockEC2Client) StopInstances(input *ec2.StopInstancesInput) (*ec2.Stop
 	}
 
 	if !found {
-		return nil, fmt.Errorf("Couldn't find any instance matching requirement")
+		return nil, fmt.Errorf("InvalidInstanceID.NotFound: The instance IDs do not exist")
 	}
 
 	return &ec2.StopInstancesOutput{


### PR DESCRIPTION
**What this PR does / why we need it**:
Till now for cases where a machine obj has ProviderID but the instance on provider is not found , deletion had been be retried.
With This PR if the AWS api returns `InvalidInstanceIDNotFound` error (which was earlier taken as an Internal error and not handled) , the instance deletion is assumed to be success.

Eventual consistency can't occur in this case as [another PR](https://github.com/gardener/machine-controller-manager-provider-aws/pull/58) handles that case for CreateMachine and so it can't reach DeleteMachine.
Also in worst case if instance still exists and we assumed its deletion with this new logic, orphan VM collection will deal with it.

**Which issue(s) this PR fixes**:
Fixes #56 

**Special notes for your reviewer**:
I have changed the mockClient functions to return `InvalidInstanceIDNotFound` error in case instance is not found (which was not done earlier) . This mimics the actual behavior of AWS API.
The existing testcases are changed accordingly
Also wait for 5min is NOT introduced, as that would deviate the code from other providers a lot.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
The machine obj will be deleted if the AWS API indicate absence of backing instance. Earlier retrying used to happen, which led to cases where machine obj never got deleted.
```
