### PR TITLE
set instance metadata HttpPutResponseHopLimit to 2

### DIFF
--- a/pkg/aws/core.go
+++ b/pkg/aws/core.go
@@ -45,6 +45,9 @@ const (
 	// awsEBSDriverName is the name of the CSI driver for EBS
 	awsEBSDriverName = "ebs.csi.aws.com"
 	awsPlacement     = "machine.sapcloud.io/awsPlacement"
+	// InstanceMetadataResponseHopLimit HTTP PUT response hop limit for instance metadata requests
+	// the default is 1 which makes it inaccessible from inside containers
+	InstanceMetadataResponseHopLimit = 2
 )
 
 // NewAWSDriver returns an empty AWSDriver object
@@ -154,6 +157,9 @@ func (d *Driver) CreateMachine(ctx context.Context, req *driver.CreateMachineReq
 		IamInstanceProfile:  iam,
 		NetworkInterfaces:   networkInterfaceSpecs,
 		TagSpecifications:   []*ec2.TagSpecification{tagInstance, tagVolume},
+		MetadataOptions: &ec2.InstanceMetadataOptionsRequest{
+			HttpPutResponseHopLimit: aws.Int64(InstanceMetadataResponseHopLimit),
+		},
 	}
 
 	// Set the AWS Capacity Reservation target. Using an 'open' preference means that if the reservation is not found, then


### PR DESCRIPTION
**What this PR does / why we need it**:

Set instance metadata http response hop limit to 2. This allows using EC2 IAM Roles from inside pods running on aws instances.

**Which issue(s) this PR fixes**:
More info here: https://github.com/gardener/gardener-extension-provider-aws/issues/468
This is approach is taken by AWS's own EKS.
https://aws.amazon.com/about-aws/whats-new/2020/08/amazon-eks-supports-ec2-instance-metadata-service-v2/
> Now, newly launched and any updated EKS managed node groups will be configured with a metadata token response hop limit set to 2.

**Release note**:
```feature user
Instance metadata http PUT response hop limit is set to 2. Allows using EC2 IAM roles.
```
