### PR TITLE
Correction in auto-revendoring script

### DIFF
--- a/.ci/set_dependency_version
+++ b/.ci/set_dependency_version
@@ -31,7 +31,7 @@ echo -n "${DEPENDENCY_VERSION}" > "${MCM_FILEPATH}"
 echo "set dependency-version of ${DEPENDENCY_NAME} to ${DEPENDENCY_VERSION}"
 
 cd ${MAIN_REPO_DIR}
-old_version=$(cat go.mod | grep github.com/gardener/machine-controller-manager | xargs)
+old_version=$(cat go.mod | grep "github.com/gardener/machine-controller-manager v" | xargs)
 new_version="github.com/gardener/machine-controller-manager ${DEPENDENCY_VERSION}"
 sed -i -- 's#'"${old_version}"'#'"${new_version}"'#g' go.mod
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the auto-revendoring script in .ci folder. 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
