### PR TITLE
Rework Orphan Collection Deletion

### DIFF
--- a/test/integration/provider/aws.go
+++ b/test/integration/provider/aws.go
@@ -232,21 +232,21 @@ func DeleteNetworkInterface(ses *session.Session, networkInterfaceID string) err
 
 func cleanOrphanResources(orphanVms []string, orphanVolumes []string, orphanNICs []string, machineClass *v1alpha1.MachineClass, secretData map[string][]byte) (delErrOrphanVms []string, delErrOrphanVolumes []string, delErrOrphanNICs []string) {
 	sess := newSession(machineClass, &v1.Secret{Data: secretData})
-	for _, instanceId := range orphanVms {
-		if err := TerminateInstance(sess, instanceId); err != nil {
-			delErrOrphanVms = append(delErrOrphanVms, instanceId)
+	for _, instanceID := range orphanVms {
+		if err := TerminateInstance(sess, instanceID); err != nil {
+			delErrOrphanVms = append(delErrOrphanVms, instanceID)
 		}
 	}
 
-	for _, volumeId := range orphanVolumes {
-		if err := DeleteVolume(sess, volumeId); err != nil {
-			delErrOrphanVolumes = append(delErrOrphanVolumes, volumeId)
+	for _, volumeID := range orphanVolumes {
+		if err := DeleteVolume(sess, volumeID); err != nil {
+			delErrOrphanVolumes = append(delErrOrphanVolumes, volumeID)
 		}
 	}
 
-	for _, networkInterfaceId := range orphanNICs {
-		if err := DeleteNetworkInterface(sess, networkInterfaceId); err != nil {
-			delErrOrphanNICs = append(delErrOrphanNICs, networkInterfaceId)
+	for _, networkInterfaceID := range orphanNICs {
+		if err := DeleteNetworkInterface(sess, networkInterfaceID); err != nil {
+			delErrOrphanNICs = append(delErrOrphanNICs, networkInterfaceID)
 		}
 	}
 

--- a/test/integration/provider/aws.go
+++ b/test/integration/provider/aws.go
@@ -230,22 +230,25 @@ func DeleteNetworkInterface(ses *session.Session, networkInterfaceID string) err
 	return nil
 }
 
-func cleanOrphanResources(orphanVms []string, orphanVolumes []string, orphanNics []string, machineClass *v1alpha1.MachineClass, secretData map[string][]byte) (delOrphanVms []string, delOrphanVolumes []string, delOrphanNics []string) {
+func cleanOrphanResources(orphanVms []string, orphanVolumes []string, orphanNICs []string, machineClass *v1alpha1.MachineClass, secretData map[string][]byte) (delErrOrphanVms []string, delErrOrphanVolumes []string, delErrOrphanNICs []string) {
 	sess := newSession(machineClass, &v1.Secret{Data: secretData})
 	for _, instanceId := range orphanVms {
 		if err := TerminateInstance(sess, instanceId); err != nil {
-			delOrphanVms = append(delOrphanVms, instanceId)
+			delErrOrphanVms = append(delErrOrphanVms, instanceId)
 		}
 	}
+
 	for _, volumeId := range orphanVolumes {
 		if err := DeleteVolume(sess, volumeId); err != nil {
-			delOrphanVolumes = append(delOrphanVolumes, volumeId)
+			delErrOrphanVolumes = append(delErrOrphanVolumes, volumeId)
 		}
 	}
-	for _, networkInterfaceId := range orphanNics {
+
+	for _, networkInterfaceId := range orphanNICs {
 		if err := DeleteNetworkInterface(sess, networkInterfaceId); err != nil {
-			delOrphanNics = append(delOrphanNics, networkInterfaceId)
+			delErrOrphanNICs = append(delErrOrphanNICs, networkInterfaceId)
 		}
 	}
+
 	return
 }

--- a/test/integration/provider/rti.go
+++ b/test/integration/provider/rti.go
@@ -26,18 +26,19 @@ func (r *ResourcesTrackerImpl) InitializeResourcesTracker(machineClass *v1alpha1
 		fmt.Printf("Error in initial probe of orphaned resources: %s", err.Error())
 		return err
 	}
+
+	orphanVMs, orphanVolumes, orphanNics := cleanOrphanResources(initialVMs, initialVolumes, initialNICs, r.MachineClass, r.SecretData)
 	//TODO: create a cleanup function to delete the list of orphan resources.
-	// 1. get list of orphan resources.
-	// 2. Mark them for deletion and call cleanup.
-	// 3. Print the orphan resources which got error in deletion.
-	if initialVMs != nil || initialVolumes != nil || initialMachines != nil || initialNICs != nil {
-		err := fmt.Errorf("orphan resources are available. Clean them up before proceeding with the test.\nvirtual machines: %v\ndisks: %v\nmcm machines: %v\nnics: %v", initialVMs, initialVolumes, initialMachines, initialNICs)
+	// 1. get list of orphan resources. (done)
+	// 2. Mark them for deletion and call cleanup. (done)
+	// 3. Print the orphan resources which got error in deletion. (done)
+	// check what is VM vs machines
+	if orphanVMs != nil || orphanVolumes != nil || initialMachines != nil || orphanNics != nil {
+		err := fmt.Errorf("orphan resources are available. Clean them up before proceeding with the test.\nvirtual machines: %v\ndisks: %v\nmcm machines: %v\nnics: %v", orphanVMs, orphanVolumes, initialMachines, orphanNics)
 		return err
 	}
 	return nil
 }
-
-//TODO: Probe resources shouldn't delete the orphans only list them.
 
 // probeResources will look for resources currently available and returns them
 func (r *ResourcesTrackerImpl) probeResources() ([]string, []string, []string, []string, error) {

--- a/test/integration/provider/rti.go
+++ b/test/integration/provider/rti.go
@@ -26,13 +26,18 @@ func (r *ResourcesTrackerImpl) InitializeResourcesTracker(machineClass *v1alpha1
 		fmt.Printf("Error in initial probe of orphaned resources: %s", err.Error())
 		return err
 	}
-
+	//TODO: create a cleanup function to delete the list of orphan resources.
+	// 1. get list of orphan resources.
+	// 2. Mark them for deletion and call cleanup.
+	// 3. Print the orphan resources which got error in deletion.
 	if initialVMs != nil || initialVolumes != nil || initialMachines != nil || initialNICs != nil {
 		err := fmt.Errorf("orphan resources are available. Clean them up before proceeding with the test.\nvirtual machines: %v\ndisks: %v\nmcm machines: %v\nnics: %v", initialVMs, initialVolumes, initialMachines, initialNICs)
 		return err
 	}
 	return nil
 }
+
+//TODO: Probe resources shouldn't delete the orphans only list them.
 
 // probeResources will look for resources currently available and returns them
 func (r *ResourcesTrackerImpl) probeResources() ([]string, []string, []string, []string, error) {

--- a/test/integration/provider/rti.go
+++ b/test/integration/provider/rti.go
@@ -79,19 +79,15 @@ func (r *ResourcesTrackerImpl) IsOrphanedResourcesAvailable() bool {
 		fmt.Printf("Error probing orphaned resources: %s", err.Error())
 		return true
 	}
-
-	if afterTestExecutionVMs != nil || afterTestExecutionAvailDisks != nil || afterTestExecutionAvailmachines != nil {
-		fmt.Printf("attempting to delete orphan resrouces... the following resources are orphaned\n")
-		fmt.Printf("Virtual Machines: %v\nVolumes: %v\nMCM Machines: %v\n", afterTestExecutionVMs, afterTestExecutionAvailDisks, afterTestExecutionAvailmachines)
+	if afterTestExecutionVMs != nil || afterTestExecutionAvailDisks != nil || afterTestExecutionAvailmachines != nil || afterTestExecutionNICs != nil {
+		fmt.Printf("The following resources are orphans ... trying to delete them \n")
+		fmt.Printf("Virtual Machines: %v\nVolumes: %v\nNICs: %v\nMCM Machines %v\n ", afterTestExecutionVMs, afterTestExecutionAvailDisks, afterTestExecutionNICs, afterTestExecutionAvailmachines)
+	}
+	orphanVMs, orphanVolumes, orphanNICs := cleanOrphanResources(afterTestExecutionVMs, afterTestExecutionAvailDisks, afterTestExecutionNICs, r.MachineClass, r.SecretData)
+	if orphanVMs != nil || orphanVolumes != nil || orphanNICs != nil || afterTestExecutionAvailmachines != nil {
+		fmt.Printf("The following resources couldn't be deleted ... \n")
+		fmt.Printf("Virtual Machines: %v\nVolumes: %v\nNICs: %v\nMCM Machines %v\n ", orphanVMs, orphanVolumes, orphanNICs, afterTestExecutionAvailmachines)
 		return true
 	}
-
-	if afterTestExecutionNICs != nil {
-		fmt.Printf("Manually delete the orphan NICs after the test!\n")
-		fmt.Printf("NICs: %v\n", afterTestExecutionNICs)
-		return true
-	}
-
 	return false
-
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The proposed solution for the issue #64, 
**Which issue(s) this PR fixes**:
Fixes #64 
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
probeResources() now doesn't try to delete orphan resources but only lists them.
The beforeSuite for IT test now calls for cleanup of orphan resources separately.
The Integration Test, which looks for orphan resources, now doesn't try to delete the orphan resources and just waits for them to be done automatically.
```
