### PR TITLE
Removing IOPS validation

### DIFF
--- a/pkg/aws/apis/aws_provider_spec.go
+++ b/pkg/aws/apis/aws_provider_spec.go
@@ -160,7 +160,7 @@ type AWSEbsBlockDeviceSpec struct {
 	// and bursting, see Amazon EBS Volume Types (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)
 	// in the Amazon Elastic Compute Cloud User Guide.
 	//
-	// Constraint: Constraint: IOPS should be a positive value.
+	// Constraint: IOPS should be a positive value.
 	// Validation of IOPS (i.e. whether it is allowed and is in the specified range for a particular volume type) is done on aws side.
 	//
 	// Condition: This parameter is required for requests to create io1 volumes;

--- a/pkg/aws/apis/aws_provider_spec.go
+++ b/pkg/aws/apis/aws_provider_spec.go
@@ -153,18 +153,18 @@ type AWSEbsBlockDeviceSpec struct {
 	Encrypted bool `json:"encrypted,omitempty"`
 
 	// The number of I/O operations per second (IOPS) that the volume supports.
-	// For io1, this represents the number of IOPS that are provisioned for the
+	// For io1 and gp3, this represents the number of IOPS that are provisioned for the
 	// volume. For gp2, this represents the baseline performance of the volume and
 	// the rate at which the volume accumulates I/O credits for bursting. For more
 	// information about General Purpose SSD baseline performance, I/O credits,
 	// and bursting, see Amazon EBS Volume Types (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)
 	// in the Amazon Elastic Compute Cloud User Guide.
 	//
-	// Constraint: Range is 100-20000 IOPS for io1 volumes and 100-10000 IOPS for
-	// gp2 volumes.
+	// Constraint: Constraint: IOPS should be a positive value.
+	// Validation of IOPS (i.e. whether it is allowed and is in the specified range for a particular volume type) is done on aws side.
 	//
 	// Condition: This parameter is required for requests to create io1 volumes;
-	// it is not used in requests to create gp2, st1, sc1, or standard volumes.
+	// Do not specify it in requests to create gp2, st1, sc1, or standard volumes.
 	Iops int64 `json:"iops,omitempty"`
 
 	// Identifier (key ID, key alias, ID ARN, or alias ARN) for a customer managed
@@ -191,7 +191,7 @@ type AWSEbsBlockDeviceSpec struct {
 	// a volume size, the default is the snapshot size.
 	VolumeSize int64 `json:"volumeSize,omitempty"`
 
-	// The volume type: gp2, io1, st1, sc1, or standard.
+	// The volume type: gp2, gp3, io1, st1, sc1, or standard.
 	//
 	// Default: standard
 	VolumeType string `json:"volumeType,omitempty"`

--- a/pkg/aws/apis/validation/validation.go
+++ b/pkg/aws/apis/validation/validation.go
@@ -123,10 +123,9 @@ func validateBlockDevices(blockDevices []awsapi.AWSBlockDeviceMappingSpec, fldPa
 			allErrs = append(allErrs, field.Required(idxPath.Child("ebs.volumeSize"), "Please mention a valid EBS volume size"))
 		}
 
-		if disk.Ebs.VolumeType == awsapi.VolumeTypeIO1 && disk.Ebs.Iops <= 0 {
+		if disk.Ebs.Iops < 0 || (disk.Ebs.VolumeType == awsapi.VolumeTypeIO1 && disk.Ebs.Iops == 0) {
 			allErrs = append(allErrs, field.Required(idxPath.Child("ebs.iops"), "Please mention a valid EBS volume iops"))
 		}
-
 	}
 
 	if rootPartitionCount > 1 {

--- a/pkg/aws/apis/validation/validation_test.go
+++ b/pkg/aws/apis/validation/validation_test.go
@@ -834,6 +834,91 @@ var _ = Describe("Validation", func() {
 					},
 				},
 			}),
+			Entry("EBS volume of type gp3 is missing iops field", &data{
+				setup: setup{},
+				action: action{
+					spec: &awsapi.AWSProviderSpec{
+						AMI: "ami-123456789",
+						BlockDevices: []awsapi.AWSBlockDeviceMappingSpec{
+							{
+								Ebs: awsapi.AWSEbsBlockDeviceSpec{
+									VolumeSize: 50,
+									VolumeType: "gp3",
+								},
+							},
+						},
+						IAM: awsapi.AWSIAMProfileSpec{
+							Name: "test-iam",
+						},
+						Region:      "eu-west-1",
+						MachineType: "m4.large",
+						KeyName:     "test-ssh-publickey",
+						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
+							{
+								SecurityGroupIDs: []string{
+									"sg-00002132323",
+								},
+								SubnetID: "subnet-123456",
+							},
+						},
+						Tags: map[string]string{
+							"kubernetes.io/cluster/shoot--test": "1",
+							"kubernetes.io/role/test":           "1",
+						},
+					},
+					secret: providerSecret,
+				},
+				expect: expect{
+					errToHaveOccurred: false,
+				},
+			}),
+			Entry("Invalid EBS volume iops", &data{
+				setup: setup{},
+				action: action{
+					spec: &awsapi.AWSProviderSpec{
+						AMI: "ami-123456789",
+						BlockDevices: []awsapi.AWSBlockDeviceMappingSpec{
+							{
+								Ebs: awsapi.AWSEbsBlockDeviceSpec{
+									VolumeSize: 50,
+									Iops:       -100,
+									VolumeType: "gp3",
+								},
+							},
+						},
+						IAM: awsapi.AWSIAMProfileSpec{
+							Name: "test-iam",
+						},
+						Region:      "eu-west-1",
+						MachineType: "m4.large",
+						KeyName:     "test-ssh-publickey",
+						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
+							{
+								SecurityGroupIDs: []string{
+									"sg-00002132323",
+								},
+								SubnetID: "subnet-123456",
+							},
+						},
+						Tags: map[string]string{
+							"kubernetes.io/cluster/shoot--test": "1",
+							"kubernetes.io/role/test":           "1",
+						},
+					},
+					secret: providerSecret,
+				},
+				expect: expect{
+					errToHaveOccurred: true,
+					errList: field.ErrorList{
+						{
+							Type:     "FieldValueRequired",
+							Field:    "providerSpec.blockDevices[0].ebs.iops",
+							BadValue: "",
+							Detail:   "Please mention a valid EBS volume iops",
+						},
+					},
+				},
+			}),
 			Entry("Network Interfaces are missing", &data{
 				setup: setup{},
 				action: action{

--- a/pkg/aws/core_util.go
+++ b/pkg/aws/core_util.go
@@ -208,7 +208,7 @@ func (d *Driver) generateBlockDevices(blockDevices []api.AWSBlockDeviceMappingSp
 			blkDeviceMapping.Ebs.DeleteOnTermination = aws.Bool(true)
 		}
 
-		if volumeType == "io1" {
+		if disk.Ebs.Iops > 0 {
 			blkDeviceMapping.Ebs.Iops = aws.Int64(disk.Ebs.Iops)
 		}
 

--- a/pkg/aws/core_util_test.go
+++ b/pkg/aws/core_util_test.go
@@ -124,6 +124,25 @@ var _ = Describe("CoreUtils", func() {
 						VolumeType: "io1",
 					},
 				},
+				{
+					DeviceName: "/dev/xvdg",
+					Ebs: api.AWSEbsBlockDeviceSpec{
+						DeleteOnTermination: aws.Bool(false),
+						Encrypted:           true,
+						Iops:                1000,
+						VolumeSize:          10,
+						VolumeType:          "gp3",
+					},
+				},
+				{
+					DeviceName: "/dev/xvdg",
+					Ebs: api.AWSEbsBlockDeviceSpec{
+						DeleteOnTermination: aws.Bool(false),
+						Encrypted:           true,
+						VolumeSize:          10,
+						VolumeType:          "gp3",
+					},
+				},
 			}
 
 			rootDevice := aws.String("/dev/sda")
@@ -157,6 +176,26 @@ var _ = Describe("CoreUtils", func() {
 						VolumeSize:          aws.Int64(64),
 						Iops:                aws.Int64(100),
 						VolumeType:          aws.String("io1"),
+					},
+				},
+				{
+					DeviceName: aws.String("/dev/xvdg"),
+					Ebs: &ec2.EbsBlockDevice{
+						DeleteOnTermination: aws.Bool(false),
+						Encrypted:           aws.Bool(true),
+						VolumeSize:          aws.Int64(10),
+						Iops:                aws.Int64(1000),
+						VolumeType:          aws.String("gp3"),
+					},
+				},
+				{
+					DeviceName: aws.String("/dev/xvdg"),
+					Ebs: &ec2.EbsBlockDevice{
+						DeleteOnTermination: aws.Bool(false),
+						Encrypted:           aws.Bool(true),
+						VolumeSize:          aws.Int64(10),
+						Iops:                nil,
+						VolumeType:          aws.String("gp3"),
 					},
 				},
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR will allow setting IOPS for any volume type 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Testing on the dev landscape is completed
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```enhancement user
Users can now set IOPS for a GP3 volume type. There is no change for IO1. Validation of IOPS (i.e. whether it is allowed and is in the specified range for a volume type) is done on the AWS side, so feedback will arrive once the volume starts getting created.
```
