### PR TITLE
Change base image from alpine to distroless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-#############      builder                                  #############
+#############      builder                          #############
 FROM golang:1.17.9 AS builder
 
 WORKDIR /go/src/github.com/gardener/machine-controller-manager-provider-aws
@@ -6,14 +6,9 @@ COPY . .
 
 RUN .ci/build
 
-#############      base                                     #############
-FROM alpine:3.15.4 as base
-
-RUN apk add --update bash curl tzdata
-WORKDIR /
-
 #############      machine-controller               #############
-FROM base AS machine-controller
+FROM gcr.io/distroless/static-debian11:nonroot AS machine-controller
+WORKDIR /
 
 COPY --from=builder /go/src/github.com/gardener/machine-controller-manager-provider-aws/bin/rel/machine-controller /machine-controller
 ENTRYPOINT ["/machine-controller"]


### PR DESCRIPTION
/area security
/kind enhancement

**What this PR does / why we need it**:
Similar to https://github.com/gardener/machine-controller-manager-provider-openstack/pull/62

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
machine-controller-manager-provider-aws now uses `distroless` instead of `alpine` as a base image.
```
