### PR TITLE
Adding `throughput` field for volumes in provider spec

### DIFF
--- a/pkg/aws/apis/aws_provider_spec.go
+++ b/pkg/aws/apis/aws_provider_spec.go
@@ -167,6 +167,13 @@ type AWSEbsBlockDeviceSpec struct {
 	// Do not specify it in requests to create gp2, st1, sc1, or standard volumes.
 	Iops int64 `json:"iops,omitempty"`
 
+	// The throughput that the volume supports, in MiB/s.
+	//
+	// This parameter is valid only for gp3 volumes.
+	//
+	// Valid Range: The range as of 16th Aug 2022 is from 125 MiB/s to 1000 MiB/s. For more info refer (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)
+	Throughput *int64 `json:"throughput,omitempty"`
+
 	// Identifier (key ID, key alias, ID ARN, or alias ARN) for a customer managed
 	// CMK under which the EBS volume is encrypted.
 	//

--- a/pkg/aws/apis/validation/validation.go
+++ b/pkg/aws/apis/validation/validation.go
@@ -126,6 +126,11 @@ func validateBlockDevices(blockDevices []awsapi.AWSBlockDeviceMappingSpec, fldPa
 		if disk.Ebs.Iops < 0 || (disk.Ebs.VolumeType == awsapi.VolumeTypeIO1 && disk.Ebs.Iops == 0) {
 			allErrs = append(allErrs, field.Required(idxPath.Child("ebs.iops"), "Please mention a valid EBS volume iops"))
 		}
+
+		// validate throughput
+		if disk.Ebs.Throughput != nil && *disk.Ebs.Throughput <= 0 {
+			allErrs = append(allErrs, field.Invalid(idxPath.Child("ebs.throughput"), *disk.Ebs.Throughput, "Throughput should be a positive value"))
+		}
 	}
 
 	if rootPartitionCount > 1 {

--- a/pkg/aws/core_util.go
+++ b/pkg/aws/core_util.go
@@ -212,6 +212,11 @@ func (d *Driver) generateBlockDevices(blockDevices []api.AWSBlockDeviceMappingSp
 			blkDeviceMapping.Ebs.Iops = aws.Int64(disk.Ebs.Iops)
 		}
 
+		// adding throughput
+		if disk.Ebs.Throughput != nil {
+			blkDeviceMapping.Ebs.Throughput = disk.Ebs.Throughput
+		}
+
 		if snapshotID != nil {
 			blkDeviceMapping.Ebs.SnapshotId = snapshotID
 		}

--- a/pkg/aws/core_util_test.go
+++ b/pkg/aws/core_util_test.go
@@ -132,6 +132,7 @@ var _ = Describe("CoreUtils", func() {
 						Iops:                1000,
 						VolumeSize:          10,
 						VolumeType:          "gp3",
+						Throughput:          aws.Int64(200),
 					},
 				},
 				{
@@ -185,6 +186,7 @@ var _ = Describe("CoreUtils", func() {
 						Encrypted:           aws.Bool(true),
 						VolumeSize:          aws.Int64(10),
 						Iops:                aws.Int64(1000),
+						Throughput:          aws.Int64(200),
 						VolumeType:          aws.String("gp3"),
 					},
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes it possible to configure `throughput` for different volume types. As of today it is configurable only for `gp3` volume type and will return an error from the provider side if specified for any other volume type.

**Which issue(s) this PR fixes**:
Fixes #93 

**Special notes for your reviewer**:
The following tests were performed on a cluster in the dev landscape:- (Current range of throughput is `125MiB/s - 1000MiB/s`)
(The throughput field is configured in machine class yaml and then a machine is deleted to trigger the creation of new machines. The machine controllers are run locally after scaling down the mcm running in the control plane of the dev cluster.)
1. Throughput=`-100`, Volume Type = `{gp3, io1, gp2}` -->  Error is returned with the following message:-  `Invalid value: -100: throughput must be a positive value`
2. Throughput=`300`, Volume Type = `{gp2, io1}` -->  Error message is as follows:- `InvalidBlockDeviceMapping: throughput cannot be specified with the volumeType of device '/dev/xvda'\n\tstatus code: 400`
3. Throughput=`300`, IOPS=`3500`, Volume Type = `gp3` -->  Machine with throughput=`300` and IOPS=`3500` is created. 
4. Throughput=`1001`, IOPS=`3500`, Volume Type = `gp3` --> Error message is as follows:- `InvalidParameterValue: Volume throughput of 1001 is too high; maximum is 1000.\n\tstatus code: 400`
5. Throughput=`100`, IOPS=`3500`, Volume Type = `gp3` --> machine with throughput=`125` and IOPS = `3500` is created.

In all the above cases where an error is returned, it will be shown as part of the machine status in the machine yaml. The state of the machine will be `CrashloopBackoff`.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
7. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Throughput is now configurable for volume types. Its validation i.e. whether it is allowed or not for the particular volume type and is within the range, is done on the provider(AWS) side. Currently only gp3 volume have configurable throughput.
```
