### PR TITLE
Drop `spec.KeyName` validation

### DIFF
--- a/pkg/aws/apis/aws_provider_spec.go
+++ b/pkg/aws/apis/aws_provider_spec.go
@@ -59,7 +59,7 @@ var (
 	ValidVolumeTypes = []string{VolumeTypeGP2, VolumeTypeGP3, VolumeTypeIO1, VolumeTypeST1, VolumeTypeSC1, VolumeTypeStandard}
 )
 
-//AWSProviderSpec is the spec to be used while parsing the calls.
+// AWSProviderSpec is the spec to be used while parsing the calls.
 type AWSProviderSpec struct {
 	// APIVersion determines the APIversion for the provider APIs
 	APIVersion string `json:"apiVersion,omitempty"`
@@ -82,8 +82,8 @@ type AWSProviderSpec struct {
 	// MachineType contains the EC2 instance type
 	MachineType string `json:"machineType,omitempty"`
 
-	// KeyName contains the SSH keypair
-	KeyName string `json:"keyName,omitempty"`
+	// KeyName is an optional field that contains the SSH keypair
+	KeyName *string `json:"keyName,omitempty"`
 
 	// Monitoring specifies if monitoring is enabled
 	Monitoring bool `json:"monitoring,omitempty"`

--- a/pkg/aws/apis/validation/validation.go
+++ b/pkg/aws/apis/validation/validation.go
@@ -52,9 +52,6 @@ func ValidateAWSProviderSpec(spec *awsapi.AWSProviderSpec, secret *corev1.Secret
 	if ("" == spec.IAM.Name && "" == spec.IAM.ARN) || ("" != spec.IAM.Name && "" != spec.IAM.ARN) {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("iam"), spec.IAM, "either IAM Name or ARN must be set"))
 	}
-	if "" == spec.KeyName {
-		allErrs = append(allErrs, field.Required(fldPath.Child("keyName"), "KeyName is required"))
-	}
 
 	allErrs = append(allErrs, validateBlockDevices(spec.BlockDevices, fldPath.Child("blockDevices"))...)
 	allErrs = append(allErrs, validateCapacityReservations(spec.CapacityReservationTarget, fldPath.Child("capacityReservation"))...)

--- a/pkg/aws/apis/validation/validation_test.go
+++ b/pkg/aws/apis/validation/validation_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"k8s.io/utils/pointer"
 
 	awsapi "github.com/gardener/machine-controller-manager-provider-aws/pkg/aws/apis"
 	. "github.com/onsi/ginkgo"
@@ -69,7 +70,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     "test-ssh-publickey",
+						KeyName:     pointer.String("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -108,7 +109,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     "test-ssh-publickey",
+						KeyName:     pointer.String("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -148,7 +149,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     "test-ssh-publickey",
+						KeyName:     pointer.String("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -185,7 +186,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     "test-ssh-publickey",
+						KeyName:     pointer.String("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -230,7 +231,7 @@ var _ = Describe("Validation", func() {
 							Name: "test-iam",
 						},
 						MachineType: "m4.large",
-						KeyName:     "test-ssh-publickey",
+						KeyName:     pointer.String("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -275,7 +276,7 @@ var _ = Describe("Validation", func() {
 							Name: "test-iam",
 						},
 						Region:  "eu-west-1",
-						KeyName: "test-ssh-publickey",
+						KeyName: pointer.String("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -319,7 +320,7 @@ var _ = Describe("Validation", func() {
 						IAM:         awsapi.AWSIAMProfileSpec{},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     "test-ssh-publickey",
+						KeyName:     pointer.String("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -366,7 +367,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     "test-ssh-publickey",
+						KeyName:     pointer.String("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -415,7 +416,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     "test-ssh-publickey",
+						KeyName:     pointer.String("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -460,7 +461,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     "test-ssh-publickey",
+						KeyName:     pointer.String("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -513,7 +514,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     "test-ssh-publickey",
+						KeyName:     pointer.String("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -559,7 +560,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     "test-ssh-publickey",
+						KeyName:     pointer.String("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -620,7 +621,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     "test-ssh-publickey",
+						KeyName:     pointer.String("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -666,7 +667,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     "test-ssh-publickey",
+						KeyName:     pointer.String("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -711,7 +712,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     "test-ssh-publickey",
+						KeyName:     pointer.String("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -757,7 +758,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     "test-ssh-publickey",
+						KeyName:     pointer.String("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -803,7 +804,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     "test-ssh-publickey",
+						KeyName:     pointer.String("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -849,7 +850,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     "test-ssh-publickey",
+						KeyName:     pointer.String("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -888,7 +889,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     "test-ssh-publickey",
+						KeyName:     pointer.String("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -936,7 +937,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     "test-ssh-publickey",
+						KeyName:     pointer.String("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -982,7 +983,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     "test-ssh-publickey",
+						KeyName:     pointer.String("test-ssh-publickey"),
 						Tags: map[string]string{
 							"kubernetes.io/cluster/shoot--test": "1",
 							"kubernetes.io/role/test":           "1",
@@ -1020,7 +1021,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     "test-ssh-publickey",
+						KeyName:     pointer.String("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -1065,7 +1066,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     "test-ssh-publickey",
+						KeyName:     pointer.String("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SubnetID: "subnet-123456",
@@ -1108,7 +1109,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     "test-ssh-publickey",
+						KeyName:     pointer.String("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -1159,7 +1160,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     "test-ssh-publickey",
+						KeyName:     pointer.String("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -1210,7 +1211,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     "test-ssh-publickey",
+						KeyName:     pointer.String("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -1254,7 +1255,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     "test-ssh-publickey",
+						KeyName:     pointer.String("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -1305,7 +1306,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     "test-ssh-publickey",
+						KeyName:     pointer.String("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{

--- a/pkg/aws/apis/validation/validation_test.go
+++ b/pkg/aws/apis/validation/validation_test.go
@@ -2,6 +2,7 @@ package validation
 
 import (
 	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
 
 	awsapi "github.com/gardener/machine-controller-manager-provider-aws/pkg/aws/apis"
@@ -392,51 +393,6 @@ var _ = Describe("Validation", func() {
 								ARN:  "bar",
 							},
 							Detail: "either IAM Name or ARN must be set",
-						},
-					},
-				},
-			}),
-			Entry("KeyName field missing", &data{
-				setup: setup{},
-				action: action{
-					spec: &awsapi.AWSProviderSpec{
-						AMI: "ami-123456789",
-						BlockDevices: []awsapi.AWSBlockDeviceMappingSpec{
-							{
-								Ebs: awsapi.AWSEbsBlockDeviceSpec{
-									VolumeSize: 50,
-									VolumeType: "gp2",
-								},
-							},
-						},
-						IAM: awsapi.AWSIAMProfileSpec{
-							Name: "test-iam",
-						},
-						Region:      "eu-west-1",
-						MachineType: "m4.large",
-						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
-							{
-								SecurityGroupIDs: []string{
-									"sg-00002132323",
-								},
-								SubnetID: "subnet-123456",
-							},
-						},
-						Tags: map[string]string{
-							"kubernetes.io/cluster/shoot--test": "1",
-							"kubernetes.io/role/test":           "1",
-						},
-					},
-					secret: providerSecret,
-				},
-				expect: expect{
-					errToHaveOccurred: true,
-					errList: field.ErrorList{
-						{
-							Type:     "FieldValueRequired",
-							Field:    "providerSpec.keyName",
-							BadValue: "",
-							Detail:   "KeyName is required",
 						},
 					},
 				},

--- a/pkg/aws/core.go
+++ b/pkg/aws/core.go
@@ -160,10 +160,13 @@ func (d *Driver) CreateMachine(ctx context.Context, req *driver.CreateMachineReq
 		MinCount:            aws.Int64(1),
 		MaxCount:            aws.Int64(1),
 		UserData:            &UserDataEnc,
-		KeyName:             aws.String(providerSpec.KeyName),
 		IamInstanceProfile:  iam,
 		NetworkInterfaces:   networkInterfaceSpecs,
 		TagSpecifications:   []*ec2.TagSpecification{tagInstance, tagVolume, tagNetworkInterface},
+	}
+
+	if len(providerSpec.KeyName) > 0 {
+		inputConfig.KeyName = aws.String(providerSpec.KeyName)
 	}
 
 	// Set the AWS Capacity Reservation target. Using an 'open' preference means that if the reservation is not found, then
@@ -240,7 +243,7 @@ func (d *Driver) CreateMachine(ctx context.Context, req *driver.CreateMachineReq
 	return response, nil
 }
 
-//returns Placement Object required in ec2.RunInstancesInput
+// returns Placement Object required in ec2.RunInstancesInput
 func getPlacementObj(req *driver.CreateMachineRequest) (*ec2.Placement, error) {
 	placementobj := &ec2.Placement{}
 

--- a/pkg/aws/core.go
+++ b/pkg/aws/core.go
@@ -165,8 +165,8 @@ func (d *Driver) CreateMachine(ctx context.Context, req *driver.CreateMachineReq
 		TagSpecifications:   []*ec2.TagSpecification{tagInstance, tagVolume, tagNetworkInterface},
 	}
 
-	if len(providerSpec.KeyName) > 0 {
-		inputConfig.KeyName = aws.String(providerSpec.KeyName)
+	if providerSpec.KeyName != nil && len(*providerSpec.KeyName) > 0 {
+		inputConfig.KeyName = aws.String(*providerSpec.KeyName)
 	}
 
 	// Set the AWS Capacity Reservation target. Using an 'open' preference means that if the reservation is not found, then

--- a/pkg/aws/migration.go
+++ b/pkg/aws/migration.go
@@ -48,7 +48,7 @@ func fillUpMachineClass(awsMachineClass *v1alpha1.AWSMachineClass, machineClass 
 		BlockDevices:      []api.AWSBlockDeviceMappingSpec{},
 		EbsOptimized:      awsMachineClass.Spec.EbsOptimized,
 		IAM:               iam,
-		KeyName:           awsMachineClass.Spec.KeyName,
+		KeyName:           &awsMachineClass.Spec.KeyName,
 		MachineType:       awsMachineClass.Spec.MachineType,
 		Monitoring:        awsMachineClass.Spec.Monitoring,
 		NetworkInterfaces: []api.AWSNetworkInterfaceSpec{},


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR drops validation for `KeyName` in `AWSProviderSpec`. Since [this PR] (https://github.com/gardener/gardener/pull/7188) it is possible to disable `sshAccess` for the worker nodes and by doing so, stop the `keyPair` rotation. In that case the `KeyName` would be an empty string.

**Which issue(s) this PR fixes**:
Part of [gardener/gardener#7481](https://github.com/gardener/gardener/issues/7481)

**Special notes for your reviewer**:
This PR is required to be merged and released for the changes in [this draft.](https://github.com/gardener/gardener-extension-provider-aws/pull/704)

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Dropped validation for `KeyName` in `AWSProviderSpec`.
```
```breaking user
`KeyName` in `AWSProviderSpec` struct has been changed to a `pointer`.
```
