### PR TITLE
Add cve categorization for mcm-provider-aws

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -14,6 +14,15 @@ machine-controller-manager-provider-aws:
                 build: ~
             registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-aws'
+            resource_labels:
+            - name: 'gardener.cloud/cve-categorisation'
+              value:
+                network_exposure: 'protected'
+                authentication_enforced: false
+                user_interaction: 'gardener-operator'
+                confidentiality_requirement: 'high'
+                integrity_requirement: 'high'
+                availability_requirement: 'low'
     steps_template: &steps_anchor
       steps:
         check:


### PR DESCRIPTION
**What this PR does / why we need it**:
Add cve categorization for mcm-provider-aws.

The categorization was initially defined here and it transferred as defined to the mcm-provider-aws repository: 
- https://github.com/gardener/gardener-extension-provider-aws/pull/684

We move the cve categorization to the mcm-provider-aws repository as the categorization can't be taken into consideration when it is defined in the respective provider extension project. Once this behaviour has changed we can remove the categorisation here again.

**Release note**:
```other operator
CVE categorization for mcm-provider-aws has been added.
```