### PR TITLE
Fix incorrect capacity reservation parameters 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ bin/
 .cache_ggshield
 .vscode
 *.test
+/tmp

--- a/kubernetes/machine-class.yaml
+++ b/kubernetes/machine-class.yaml
@@ -25,9 +25,10 @@ providerSpec:
         volumeType: gp2 # Type of the root block device
         encrypted: true
         deleteOnTermination: true
-#  capacityReservation: # Optional - allows targeting of an AWS Capacity reservation or an AWS Resource Group containing reservations. Only one needs to be specified.
-#  capacityReservationId: "cr-05c28b843c05acc11"
-#  capacityReservationResourceGroupArn: "arn:aws:resource-groups:us-west-1:123456789012:group/my-cr-group"
+#  capacityReservation: # Optional - allows targeting of an AWS Capacity reservation preference, ID or an AWS Resource Group containing reservations. Only one needs to be specified.
+#    capacityReservationPreference: "open"
+#    capacityReservationId: "cr-05c28b843c05acc11"
+#    capacityReservationResourceGroupArn: "arn:aws:resource-groups:us-west-1:123456789012:group/my-cr-group"
   iam: # either <name> or <arn> must be specified
     name: iam-name # Name of the AWS instance profile that shall be used for the machines
 #   arn: arn # ARN of the AWS instance profile that shall be used for the machines

--- a/pkg/aws/apis/aws_provider_spec.go
+++ b/pkg/aws/apis/aws_provider_spec.go
@@ -138,6 +138,9 @@ type AWSBlockDeviceMappingSpec struct {
 // indirectly using an AWS Resource Group
 type AWSCapacityReservationTargetSpec struct {
 
+	// Indicates the instance's Capacity Reservation preferences (allowed values are 'open' or 'none')
+	CapacityReservationPreference *string `json:"capacityReservationPreference,omitempty"`
+
 	// The ID of the Capacity Reservation in which to run the instance.
 	CapacityReservationID *string `json:"capacityReservationId,omitempty"`
 

--- a/pkg/aws/apis/aws_provider_spec.go
+++ b/pkg/aws/apis/aws_provider_spec.go
@@ -134,7 +134,7 @@ type AWSBlockDeviceMappingSpec struct {
 	VirtualName string `json:"virtualName,omitempty"`
 }
 
-// AWSCapacityReservationTargetSpec allows to target an AWS Capacity Reservation directly or indirectly using an AWS Resource Group.
+// AWSCapacityReservationTargetSpec allows to target an AWS Capacity Reservation directly or indirectly using an AWS Capacity Reservation.
 // See https://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#CapacityReservationSpecification for additional information.
 type AWSCapacityReservationTargetSpec struct {
 
@@ -144,7 +144,7 @@ type AWSCapacityReservationTargetSpec struct {
 	// CapacityReservationID ID of the Capacity Reservation in which to run the instance.
 	CapacityReservationID *string `json:"capacityReservationId,omitempty"`
 
-	// CapacityReservationResourceGroupArn The ARN of the Capacity Reservation resource group in which to run the instance.
+	// CapacityReservationResourceGroupArn The ARN of the Capacity Reservation in which to run the instance.
 	CapacityReservationResourceGroupArn *string `json:"capacityReservationResourceGroupArn,omitempty"`
 }
 

--- a/pkg/aws/apis/aws_provider_spec.go
+++ b/pkg/aws/apis/aws_provider_spec.go
@@ -134,17 +134,17 @@ type AWSBlockDeviceMappingSpec struct {
 	VirtualName string `json:"virtualName,omitempty"`
 }
 
-// AWSCapacityReservationTargetSpec allows to target an AWS Capacity Reservation directly or
-// indirectly using an AWS Resource Group
+// AWSCapacityReservationTargetSpec allows to target an AWS Capacity Reservation directly or indirectly using an AWS Resource Group.
+// See https://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#CapacityReservationSpecification for additional information.
 type AWSCapacityReservationTargetSpec struct {
 
-	// Indicates the instance's Capacity Reservation preferences (allowed values are 'open' or 'none')
+	// CapacityReservationPreference indicates the instance's Capacity Reservation preferences (possible values are 'open' or 'none').
 	CapacityReservationPreference *string `json:"capacityReservationPreference,omitempty"`
 
-	// The ID of the Capacity Reservation in which to run the instance.
+	// CapacityReservationID ID of the Capacity Reservation in which to run the instance.
 	CapacityReservationID *string `json:"capacityReservationId,omitempty"`
 
-	// The ARN of the Capacity Reservation resource group in which to run the instance.
+	// CapacityReservationResourceGroupArn The ARN of the Capacity Reservation resource group in which to run the instance.
 	CapacityReservationResourceGroupArn *string `json:"capacityReservationResourceGroupArn,omitempty"`
 }
 

--- a/pkg/aws/apis/validation/validation.go
+++ b/pkg/aws/apis/validation/validation.go
@@ -160,7 +160,7 @@ func validateCapacityReservations(capacityReservation *awsapi.AWSCapacityReserva
 				allErrs = append(allErrs, field.Required(fldPath, "CapacityReservationPreference cannot be set when also providing a CapacityReservationID or CapacityReservationResourceGroupArn"))
 			}
 		} else if capacityReservation.CapacityReservationID != nil && capacityReservation.CapacityReservationResourceGroupArn != nil {
-			allErrs = append(allErrs, field.Required(fldPath, "capacityReservationResourceGroupArn or capacityReservationId are optional but only one should be used"))
+			allErrs = append(allErrs, field.Required(fldPath, "CapacityReservationResourceGroupArn or CapacityReservationId are optional but only one should be used"))
 		}
 	}
 

--- a/pkg/aws/apis/validation/validation.go
+++ b/pkg/aws/apis/validation/validation.go
@@ -155,7 +155,11 @@ func validateCapacityReservations(capacityReservation *awsapi.AWSCapacityReserva
 	)
 
 	if capacityReservation != nil {
-		if capacityReservation.CapacityReservationID != nil && capacityReservation.CapacityReservationResourceGroupArn != nil {
+		if capacityReservation.CapacityReservationPreference != nil {
+			if capacityReservation.CapacityReservationID != nil || capacityReservation.CapacityReservationResourceGroupArn != nil {
+				allErrs = append(allErrs, field.Required(fldPath, "CapacityReservationPreference cannot be set when also providing a CapacityReservationID or CapacityReservationResourceGroupArn"))
+			}
+		} else if capacityReservation.CapacityReservationID != nil && capacityReservation.CapacityReservationResourceGroupArn != nil {
 			allErrs = append(allErrs, field.Required(fldPath, "capacityReservationResourceGroupArn or capacityReservationId are optional but only one should be used"))
 		}
 	}

--- a/pkg/aws/apis/validation/validation_test.go
+++ b/pkg/aws/apis/validation/validation_test.go
@@ -1678,7 +1678,7 @@ var _ = Describe("Validation", func() {
 							Type:     "FieldValueRequired",
 							Field:    "providerSpec.capacityReservation",
 							BadValue: "",
-							Detail:   "capacityReservationResourceGroupArn or capacityReservationId are optional but only one should be used",
+							Detail:   "CapacityReservationResourceGroupArn or CapacityReservationId are optional but only one should be used",
 						},
 					},
 				},

--- a/pkg/aws/apis/validation/validation_test.go
+++ b/pkg/aws/apis/validation/validation_test.go
@@ -1458,6 +1458,325 @@ var _ = Describe("Validation", func() {
 					},
 				},
 			}),
+			Entry("CapacityReservationTargetSpec invalid spec configuring both preference, target id and arn", &data{
+				setup: setup{},
+				action: action{
+					spec: &awsapi.AWSProviderSpec{
+						AMI: "ami-123456789",
+						BlockDevices: []awsapi.AWSBlockDeviceMappingSpec{
+							{
+								Ebs: awsapi.AWSEbsBlockDeviceSpec{
+									VolumeSize: 50,
+									VolumeType: "gp2",
+								},
+							},
+						},
+						CapacityReservationTarget: &awsapi.AWSCapacityReservationTargetSpec{
+							CapacityReservationPreference:       pointer.String("open"),
+							CapacityReservationID:               pointer.String("capacity-reservation-id-abcd1234"),
+							CapacityReservationResourceGroupArn: pointer.String("arn:01234:/my-resource-group"),
+						},
+						IAM: awsapi.AWSIAMProfileSpec{
+							Name: "test-iam",
+						},
+						Region:      "eu-west-1",
+						MachineType: "m4.large",
+						KeyName:     pointer.String("test-ssh-publickey"),
+						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
+							{
+								SecurityGroupIDs: []string{
+									"sg-00002132323",
+								},
+								SubnetID: "subnet-123456",
+							},
+						},
+						Tags: map[string]string{
+							"kubernetes.io/cluster/shoot--test": "1",
+							"kubernetes.io/role/test":           "1",
+						},
+					},
+					secret: &corev1.Secret{
+						Data: map[string][]byte{
+							"providerAccessKeyId":     []byte("dummy-id"),
+							"userData":                []byte("dummy-user-data"),
+							"providerSecretAccessKey": []byte("dummy-secret"),
+						},
+					},
+				},
+				expect: expect{
+					errToHaveOccurred: true,
+					errList: field.ErrorList{
+						{
+							Type:     "FieldValueRequired",
+							Field:    "providerSpec.capacityReservation",
+							BadValue: "",
+							Detail:   "CapacityReservationPreference cannot be set when also providing a CapacityReservationID or CapacityReservationResourceGroupArn",
+						},
+					},
+				},
+			}),
+			Entry("CapacityReservationTargetSpec invalid spec configuring both preference and target id", &data{
+				setup: setup{},
+				action: action{
+					spec: &awsapi.AWSProviderSpec{
+						AMI: "ami-123456789",
+						BlockDevices: []awsapi.AWSBlockDeviceMappingSpec{
+							{
+								Ebs: awsapi.AWSEbsBlockDeviceSpec{
+									VolumeSize: 50,
+									VolumeType: "gp2",
+								},
+							},
+						},
+						CapacityReservationTarget: &awsapi.AWSCapacityReservationTargetSpec{
+							CapacityReservationPreference: pointer.String("open"),
+							CapacityReservationID:         pointer.String("capacity-reservation-id-abcd1234"),
+						},
+						IAM: awsapi.AWSIAMProfileSpec{
+							Name: "test-iam",
+						},
+						Region:      "eu-west-1",
+						MachineType: "m4.large",
+						KeyName:     pointer.String("test-ssh-publickey"),
+						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
+							{
+								SecurityGroupIDs: []string{
+									"sg-00002132323",
+								},
+								SubnetID: "subnet-123456",
+							},
+						},
+						Tags: map[string]string{
+							"kubernetes.io/cluster/shoot--test": "1",
+							"kubernetes.io/role/test":           "1",
+						},
+					},
+					secret: &corev1.Secret{
+						Data: map[string][]byte{
+							"providerAccessKeyId":     []byte("dummy-id"),
+							"userData":                []byte("dummy-user-data"),
+							"providerSecretAccessKey": []byte("dummy-secret"),
+						},
+					},
+				},
+				expect: expect{
+					errToHaveOccurred: true,
+					errList: field.ErrorList{
+						{
+							Type:     "FieldValueRequired",
+							Field:    "providerSpec.capacityReservation",
+							BadValue: "",
+							Detail:   "CapacityReservationPreference cannot be set when also providing a CapacityReservationID or CapacityReservationResourceGroupArn",
+						},
+					},
+				},
+			}),
+			Entry("CapacityReservationTargetSpec invalid spec configuring both preference and arn", &data{
+				setup: setup{},
+				action: action{
+					spec: &awsapi.AWSProviderSpec{
+						AMI: "ami-123456789",
+						BlockDevices: []awsapi.AWSBlockDeviceMappingSpec{
+							{
+								Ebs: awsapi.AWSEbsBlockDeviceSpec{
+									VolumeSize: 50,
+									VolumeType: "gp2",
+								},
+							},
+						},
+						CapacityReservationTarget: &awsapi.AWSCapacityReservationTargetSpec{
+							CapacityReservationPreference:       pointer.String("open"),
+							CapacityReservationResourceGroupArn: pointer.String("arn:01234:/my-resource-group"),
+						},
+						IAM: awsapi.AWSIAMProfileSpec{
+							Name: "test-iam",
+						},
+						Region:      "eu-west-1",
+						MachineType: "m4.large",
+						KeyName:     pointer.String("test-ssh-publickey"),
+						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
+							{
+								SecurityGroupIDs: []string{
+									"sg-00002132323",
+								},
+								SubnetID: "subnet-123456",
+							},
+						},
+						Tags: map[string]string{
+							"kubernetes.io/cluster/shoot--test": "1",
+							"kubernetes.io/role/test":           "1",
+						},
+					},
+					secret: &corev1.Secret{
+						Data: map[string][]byte{
+							"providerAccessKeyId":     []byte("dummy-id"),
+							"userData":                []byte("dummy-user-data"),
+							"providerSecretAccessKey": []byte("dummy-secret"),
+						},
+					},
+				},
+				expect: expect{
+					errToHaveOccurred: true,
+					errList: field.ErrorList{
+						{
+							Type:     "FieldValueRequired",
+							Field:    "providerSpec.capacityReservation",
+							BadValue: "",
+							Detail:   "CapacityReservationPreference cannot be set when also providing a CapacityReservationID or CapacityReservationResourceGroupArn",
+						},
+					},
+				},
+			}),
+			Entry("CapacityReservationTargetSpec invalid spec configuring both id and arn", &data{
+				setup: setup{},
+				action: action{
+					spec: &awsapi.AWSProviderSpec{
+						AMI: "ami-123456789",
+						BlockDevices: []awsapi.AWSBlockDeviceMappingSpec{
+							{
+								Ebs: awsapi.AWSEbsBlockDeviceSpec{
+									VolumeSize: 50,
+									VolumeType: "gp2",
+								},
+							},
+						},
+						CapacityReservationTarget: &awsapi.AWSCapacityReservationTargetSpec{
+							CapacityReservationID:               pointer.String("capacity-reservation-id-abcd1234"),
+							CapacityReservationResourceGroupArn: pointer.String("arn:01234:/my-resource-group"),
+						},
+						IAM: awsapi.AWSIAMProfileSpec{
+							Name: "test-iam",
+						},
+						Region:      "eu-west-1",
+						MachineType: "m4.large",
+						KeyName:     pointer.String("test-ssh-publickey"),
+						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
+							{
+								SecurityGroupIDs: []string{
+									"sg-00002132323",
+								},
+								SubnetID: "subnet-123456",
+							},
+						},
+						Tags: map[string]string{
+							"kubernetes.io/cluster/shoot--test": "1",
+							"kubernetes.io/role/test":           "1",
+						},
+					},
+					secret: &corev1.Secret{
+						Data: map[string][]byte{
+							"providerAccessKeyId":     []byte("dummy-id"),
+							"userData":                []byte("dummy-user-data"),
+							"providerSecretAccessKey": []byte("dummy-secret"),
+						},
+					},
+				},
+				expect: expect{
+					errToHaveOccurred: true,
+					errList: field.ErrorList{
+						{
+							Type:     "FieldValueRequired",
+							Field:    "providerSpec.capacityReservation",
+							BadValue: "",
+							Detail:   "capacityReservationResourceGroupArn or capacityReservationId are optional but only one should be used",
+						},
+					},
+				},
+			}),
+			Entry("CapacityReservationTargetSpec valid spec configuring only CapacityReservationID", &data{
+				setup: setup{},
+				action: action{
+					spec: &awsapi.AWSProviderSpec{
+						AMI: "ami-123456789",
+						BlockDevices: []awsapi.AWSBlockDeviceMappingSpec{
+							{
+								Ebs: awsapi.AWSEbsBlockDeviceSpec{
+									VolumeSize: 50,
+									VolumeType: "gp2",
+								},
+							},
+						},
+						CapacityReservationTarget: &awsapi.AWSCapacityReservationTargetSpec{
+							CapacityReservationID: pointer.String("capacity-reservation-id-abcd1234"),
+						},
+						IAM: awsapi.AWSIAMProfileSpec{
+							Name: "test-iam",
+						},
+						Region:      "eu-west-1",
+						MachineType: "m4.large",
+						KeyName:     pointer.String("test-ssh-publickey"),
+						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
+							{
+								SecurityGroupIDs: []string{
+									"sg-00002132323",
+								},
+								SubnetID: "subnet-123456",
+							},
+						},
+						Tags: map[string]string{
+							"kubernetes.io/cluster/shoot--test": "1",
+							"kubernetes.io/role/test":           "1",
+						},
+					},
+					secret: &corev1.Secret{
+						Data: map[string][]byte{
+							"providerAccessKeyId":     []byte("dummy-id"),
+							"userData":                []byte("dummy-user-data"),
+							"providerSecretAccessKey": []byte("dummy-secret"),
+						},
+					},
+				},
+				expect: expect{
+					errToHaveOccurred: false,
+				},
+			}),
+			Entry("CapacityReservationTargetSpec valid spec configuring only CapacityReservationResourceGroupArn", &data{
+				setup: setup{},
+				action: action{
+					spec: &awsapi.AWSProviderSpec{
+						AMI: "ami-123456789",
+						BlockDevices: []awsapi.AWSBlockDeviceMappingSpec{
+							{
+								Ebs: awsapi.AWSEbsBlockDeviceSpec{
+									VolumeSize: 50,
+									VolumeType: "gp2",
+								},
+							},
+						},
+						CapacityReservationTarget: &awsapi.AWSCapacityReservationTargetSpec{
+							CapacityReservationResourceGroupArn: pointer.String("arn:01234:/my-resource-group"),
+						},
+						IAM: awsapi.AWSIAMProfileSpec{
+							Name: "test-iam",
+						},
+						Region:      "eu-west-1",
+						MachineType: "m4.large",
+						KeyName:     pointer.String("test-ssh-publickey"),
+						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
+							{
+								SecurityGroupIDs: []string{
+									"sg-00002132323",
+								},
+								SubnetID: "subnet-123456",
+							},
+						},
+						Tags: map[string]string{
+							"kubernetes.io/cluster/shoot--test": "1",
+							"kubernetes.io/role/test":           "1",
+						},
+					},
+					secret: &corev1.Secret{
+						Data: map[string][]byte{
+							"providerAccessKeyId":     []byte("dummy-id"),
+							"userData":                []byte("dummy-user-data"),
+							"providerSecretAccessKey": []byte("dummy-secret"),
+						},
+					},
+				},
+				expect: expect{
+					errToHaveOccurred: false,
+				},
+			}),
 		)
 	})
 })
@@ -1472,6 +1791,9 @@ func validAWSProviderSpec() *awsapi.AWSProviderSpec {
 					VolumeType: "gp2",
 				},
 			},
+		},
+		CapacityReservationTarget: &awsapi.AWSCapacityReservationTargetSpec{
+			CapacityReservationPreference: pointer.String("open"),
 		},
 		IAM: awsapi.AWSIAMProfileSpec{
 			Name: "test-iam",

--- a/pkg/aws/core.go
+++ b/pkg/aws/core.go
@@ -185,14 +185,12 @@ func (d *Driver) CreateMachine(ctx context.Context, req *driver.CreateMachineReq
 	if providerSpec.CapacityReservationTarget != nil {
 		if providerSpec.CapacityReservationTarget.CapacityReservationResourceGroupArn != nil {
 			inputConfig.CapacityReservationSpecification = &ec2.CapacityReservationSpecification{
-				CapacityReservationPreference: aws.String("open"),
 				CapacityReservationTarget: &ec2.CapacityReservationTarget{
 					CapacityReservationResourceGroupArn: providerSpec.CapacityReservationTarget.CapacityReservationResourceGroupArn,
 				},
 			}
 		} else if providerSpec.CapacityReservationTarget.CapacityReservationID != nil {
 			inputConfig.CapacityReservationSpecification = &ec2.CapacityReservationSpecification{
-				CapacityReservationPreference: aws.String("open"),
 				CapacityReservationTarget: &ec2.CapacityReservationTarget{
 					CapacityReservationId: providerSpec.CapacityReservationTarget.CapacityReservationID,
 				},

--- a/pkg/aws/core.go
+++ b/pkg/aws/core.go
@@ -183,18 +183,15 @@ func (d *Driver) CreateMachine(ctx context.Context, req *driver.CreateMachineReq
 	// Set the AWS Capacity Reservation target. Using an 'open' preference means that if the reservation is not found, then
 	// instances are launched with regular on-demand capacity.
 	if providerSpec.CapacityReservationTarget != nil {
-		if providerSpec.CapacityReservationTarget.CapacityReservationResourceGroupArn != nil {
-			inputConfig.CapacityReservationSpecification = &ec2.CapacityReservationSpecification{
-				CapacityReservationTarget: &ec2.CapacityReservationTarget{
-					CapacityReservationResourceGroupArn: providerSpec.CapacityReservationTarget.CapacityReservationResourceGroupArn,
-				},
-			}
+		inputConfig.CapacityReservationSpecification = &ec2.CapacityReservationSpecification{}
+		if providerSpec.CapacityReservationTarget.CapacityReservationPreference != nil {
+			inputConfig.CapacityReservationSpecification.CapacityReservationPreference = providerSpec.CapacityReservationTarget.CapacityReservationPreference
+
+		} else if providerSpec.CapacityReservationTarget.CapacityReservationResourceGroupArn != nil {
+			inputConfig.CapacityReservationSpecification.CapacityReservationTarget.CapacityReservationResourceGroupArn = providerSpec.CapacityReservationTarget.CapacityReservationResourceGroupArn
+
 		} else if providerSpec.CapacityReservationTarget.CapacityReservationID != nil {
-			inputConfig.CapacityReservationSpecification = &ec2.CapacityReservationSpecification{
-				CapacityReservationTarget: &ec2.CapacityReservationTarget{
-					CapacityReservationId: providerSpec.CapacityReservationTarget.CapacityReservationID,
-				},
-			}
+			inputConfig.CapacityReservationSpecification.CapacityReservationTarget.CapacityReservationId = providerSpec.CapacityReservationTarget.CapacityReservationID
 		}
 	}
 

--- a/pkg/aws/core.go
+++ b/pkg/aws/core.go
@@ -183,15 +183,12 @@ func (d *Driver) CreateMachine(ctx context.Context, req *driver.CreateMachineReq
 	// Set the AWS Capacity Reservation target. Using an 'open' preference means that if the reservation is not found, then
 	// instances are launched with regular on-demand capacity.
 	if providerSpec.CapacityReservationTarget != nil {
-		inputConfig.CapacityReservationSpecification = &ec2.CapacityReservationSpecification{}
-		if providerSpec.CapacityReservationTarget.CapacityReservationPreference != nil {
-			inputConfig.CapacityReservationSpecification.CapacityReservationPreference = providerSpec.CapacityReservationTarget.CapacityReservationPreference
-
-		} else if providerSpec.CapacityReservationTarget.CapacityReservationResourceGroupArn != nil {
-			inputConfig.CapacityReservationSpecification.CapacityReservationTarget.CapacityReservationResourceGroupArn = providerSpec.CapacityReservationTarget.CapacityReservationResourceGroupArn
-
-		} else if providerSpec.CapacityReservationTarget.CapacityReservationID != nil {
-			inputConfig.CapacityReservationSpecification.CapacityReservationTarget.CapacityReservationId = providerSpec.CapacityReservationTarget.CapacityReservationID
+		inputConfig.CapacityReservationSpecification = &ec2.CapacityReservationSpecification{
+			CapacityReservationPreference: providerSpec.CapacityReservationTarget.CapacityReservationPreference,
+			CapacityReservationTarget: &ec2.CapacityReservationTarget{
+				CapacityReservationId:               providerSpec.CapacityReservationTarget.CapacityReservationID,
+				CapacityReservationResourceGroupArn: providerSpec.CapacityReservationTarget.CapacityReservationResourceGroupArn,
+			},
 		}
 	}
 

--- a/pkg/aws/core_test.go
+++ b/pkg/aws/core_test.go
@@ -201,7 +201,7 @@ var _ = Describe("MachineServer", func() {
 				},
 				expect: expect{
 					errToHaveOccurred: true,
-					errMessage:        "machine codes error: code = [Internal] message = [Error while validating ProviderSpec providerSpec.capacityReservation: Required value: capacityReservationResourceGroupArn or capacityReservationId are optional but only one should be used]",
+					errMessage:        "machine codes error: code = [Internal] message = [Error while validating ProviderSpec providerSpec.capacityReservation: Required value: CapacityReservationResourceGroupArn or CapacityReservationId are optional but only one should be used]",
 				},
 			}),
 			Entry("Machine creation request for an AWS Capacity Reservation Group with capacityReservationPreference only", &data{
@@ -839,7 +839,7 @@ var _ = Describe("MachineServer", func() {
 				ms := NewAWSDriver(mockPluginSPIImpl)
 				ctx := context.Background()
 
-				//if there is a create machine request by the test case then create the machine
+				// if there is a create machine request by the test case then create the machine
 				if data.setup.createMachineRequest != nil {
 					_, err := ms.CreateMachine(ctx, data.setup.createMachineRequest)
 					Expect(err).ToNot(HaveOccurred())
@@ -1039,7 +1039,7 @@ var _ = Describe("MachineServer", func() {
 				} else {
 					Expect(err).ToNot(HaveOccurred())
 					Expect(len(listResponse.MachineList)).To(Equal(len(data.expect.listMachineResponse.MachineList)))
-					//Expect(listResponse.MachineList).To(Equal(data.expect.listMachineResponse))
+					// Expect(listResponse.MachineList).To(Equal(data.expect.listMachineResponse))
 				}
 			},
 			Entry("Simple Machine List Request", &data{
@@ -1506,7 +1506,7 @@ var _ = Describe("MachineServer", func() {
 							Provider: ProviderAWS,
 						},
 						ClassSpec: &v1alpha1.ClassSpec{
-							//APIGroup: "",
+							// APIGroup: "",
 							Kind: AWSMachineClassKind,
 							Name: "test-mc",
 						},

--- a/pkg/aws/core_test.go
+++ b/pkg/aws/core_test.go
@@ -204,6 +204,22 @@ var _ = Describe("MachineServer", func() {
 					errMessage:        "machine codes error: code = [Internal] message = [Error while validating ProviderSpec providerSpec.capacityReservation: Required value: capacityReservationResourceGroupArn or capacityReservationId are optional but only one should be used]",
 				},
 			}),
+			Entry("Machine creation request for an AWS Capacity Reservation Group with capacityReservationPreference only", &data{
+				action: action{
+					machineRequest: &driver.CreateMachineRequest{
+						Machine:      newMachine(-1, nil),
+						MachineClass: newMachineClass([]byte("{\"ami\":\"ami-123456789\",\"blockDevices\":[{\"ebs\":{\"volumeSize\":50,\"volumeType\":\"gp2\"}}],\"iam\":{\"name\":\"test-iam\"},\"keyName\":\"test-ssh-publickey\",\"machineType\":\"m4.large\",\"networkInterfaces\":[{\"securityGroupIDs\":[\"sg-00002132323\"],\"subnetID\":\"subnet-123456\"}],\"region\":\"eu-west-1\",\"capacityReservation\":{\"capacityReservationPreference\":\"open\"},\"tags\":{\"kubernetes.io/cluster/shoot--test\":\"1\",\"kubernetes.io/role/test\":\"1\"}}")),
+						Secret:       providerSecret,
+					},
+				},
+				expect: expect{
+					machineResponse: &driver.CreateMachineResponse{
+						ProviderID: "aws:///eu-west-1/i-0123456789-0",
+						NodeName:   "ip-0",
+					},
+					errToHaveOccurred: false,
+				},
+			}),
 			Entry("Machine creation request for capacity reservations with capacityReservationId", &data{
 				action: action{
 					machineRequest: &driver.CreateMachineRequest{


### PR DESCRIPTION
**What this PR does / why we need it**:
Address the violation of the SDK restrictions around capacity reservations where currently the `CapacityReservationTarget` and `CapacityReservationPreference` is set at the same time.  This error prevents machines from being created.

**Which issue(s) this PR fixes**:
Fixes #114 and #116

**Special notes for your reviewer**:
See line 44494: https://raw.githubusercontent.com/gardener/machine-controller-manager-provider-aws/master/vendor/github.com/aws/aws-sdk-go/service/ec2/api.go

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix handling of capacity reservations in `MachineClass` that prevented correct scale up
```
