### PR TITLE
Increase timeout for IT to `10 min`

### DIFF
--- a/test/integration/controller/controller_test.go
+++ b/test/integration/controller/controller_test.go
@@ -36,7 +36,8 @@ import (
 	. "github.com/onsi/ginkgo"
 )
 
-var commons = common.NewIntegrationTestFramework(&provider.ResourcesTrackerImpl{}, 400)
+// the timeout is changed to accommodate for time taken by node-critical components to get ready. PR - https://github.com/gardener/machine-controller-manager/pull/778
+var commons = common.NewIntegrationTestFramework(&provider.ResourcesTrackerImpl{}, 600)
 
 var _ = BeforeSuite(commons.SetupBeforeSuite)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR increases the timeout for IT to `10min` to accommodate the time node-critical components take to get ready. https://github.com/gardener/machine-controller-manager/pull/778.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
