### PR TITLE
Add image reference for `upgrade-prs` cronjob

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -26,9 +26,9 @@ machine-controller-manager-provider-aws:
     steps_template: &steps_anchor
       steps:
         check:
-          image: 'golang:1.20.4'
+          image: 'golang:1.20.5'
         build:
-          image: 'golang:1.20.4'
+          image: 'golang:1.20.5'
           output_dir: 'binary'
         test:
           image: 'eu.gcr.io/gardener-project/gardener/testmachinery/base-step:stable'
@@ -55,7 +55,9 @@ machine-controller-manager-provider-aws:
         version: ~
         cronjob:
           interval: '24h'
-        update_component_deps: ~
+        update_component_deps:
+          set_dependency_version_script_container_image:
+            image_reference: 'golang:1.20.5'
     release:
       <<: *steps_anchor
       traits:

--- a/.ci/set_dependency_version
+++ b/.ci/set_dependency_version
@@ -35,6 +35,6 @@ old_version=$(cat go.mod | grep "github.com/gardener/machine-controller-manager 
 new_version="github.com/gardener/machine-controller-manager ${DEPENDENCY_VERSION}"
 sed -i -- 's#'"${old_version}"'#'"${new_version}"'#g' go.mod
 
-apk add --no-cache go make
+apk add --no-cache make
 
 make revendor

--- a/.ci/set_dependency_version
+++ b/.ci/set_dependency_version
@@ -35,6 +35,4 @@ old_version=$(cat go.mod | grep "github.com/gardener/machine-controller-manager 
 new_version="github.com/gardener/machine-controller-manager ${DEPENDENCY_VERSION}"
 sed -i -- 's#'"${old_version}"'#'"${new_version}"'#g' go.mod
 
-apk add --no-cache make
-
 make revendor

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #############      builder                          #############
-FROM golang:1.20.4 AS builder
+FROM golang:1.20.5 AS builder
 
 WORKDIR /go/src/github.com/gardener/machine-controller-manager-provider-aws
 COPY . .


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR specifies the golang container image to be used by the `create-upgrade-prs` cronjob to run the `set_dependency_version` script

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
