### PR TITLE
Keep root as working directory for `set_dependency_version`

### DIFF
--- a/.ci/set_dependency_version
+++ b/.ci/set_dependency_version
@@ -2,6 +2,9 @@
 
 set -eu
 
+# set root as the working directory first
+cd /
+
 if [ -z "${MAIN_REPO_DIR:-}" ]; then
   export MAIN_REPO_DIR="$(readlink -f "$(dirname "${0}")/..")"
 fi


### PR DESCRIPTION
**What this PR does / why we need it**:
With the change in container image to `golang:1.20.5` for running the `set_dependency_version` script, we need to set root as the present working directory.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
