### PR TITLE
Moved Declaration of dynamic content from Makefile to .env file for AWS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,18 +18,8 @@ IMAGE_REPOSITORY    := eu.gcr.io/gardener-project/gardener/machine-controller-ma
 IMAGE_TAG           := $(shell cat VERSION)
 PROVIDER_NAME       := AWS
 PROJECT_NAME        := gardener
-CONTROL_NAMESPACE	:=
-CONTROL_KUBECONFIG  := 
-TARGET_KUBECONFIG   := 
 
-# Below ones are used in tests
-MACHINECLASS_V1 	:= dev/machineclassv1.yaml
-MACHINECLASS_V2 	:= 
-MCM_IMAGE			:= 
-MC_IMAGE			:= 
-# MCM_IMAGE			:= eu.gcr.io/gardener-project/gardener/machine-controller-manager:v0.39.0
-# MC_IMAGE			:= $(IMAGE_REPOSITORY):v0.7.0
-LEADER_ELECT 	    := "true"
+LEADER_ELECT 		:= "true"
 # If Integration Test Suite is to be run locally against clusters then export the below variable
 # with MCM deployment name in the cluster
 MACHINE_CONTROLLER_MANAGER_DEPLOYMENT_NAME := machine-controller-manager
@@ -38,6 +28,7 @@ MACHINE_CONTROLLER_MANAGER_DEPLOYMENT_NAME := machine-controller-manager
 #########################################
 
 include hack/tools.mk
+include .env
 
 .PHONY: rename-provider
 rename-provider:

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ MACHINE_CONTROLLER_MANAGER_DEPLOYMENT_NAME := machine-controller-manager
 #########################################
 
 include hack/tools.mk
-include .env
+-include .env
 
 .PHONY: rename-provider
 rename-provider:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates Makefile content to import dynamic content from the .env file. 

**Which issue(s) this PR fixes**:
Fixes -> https://github.com/gardener/machine-controller-manager/issues/846

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
