### PR TITLE
Removed unwanted logs and moved dynamic content from Makefile to .env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ bin/
 *.test
 .DS_Store
 /tmp
+.env

--- a/Makefile
+++ b/Makefile
@@ -18,17 +18,7 @@ IMAGE_REPOSITORY    := eu.gcr.io/gardener-project/gardener/machine-controller-ma
 IMAGE_TAG           := $(shell cat VERSION)
 PROVIDER_NAME       := AWS
 PROJECT_NAME        := gardener
-CONTROL_NAMESPACE	:=
-CONTROL_KUBECONFIG  := 
-TARGET_KUBECONFIG   := 
 
-# Below ones are used in tests
-MACHINECLASS_V1 	:= dev/machineclassv1.yaml
-MACHINECLASS_V2 	:= 
-MCM_IMAGE			:= 
-MC_IMAGE			:= 
-# MCM_IMAGE			:= eu.gcr.io/gardener-project/gardener/machine-controller-manager:v0.39.0
-# MC_IMAGE			:= $(IMAGE_REPOSITORY):v0.7.0
 LEADER_ELECT 	    := "true"
 # If Integration Test Suite is to be run locally against clusters then export the below variable
 # with MCM deployment name in the cluster
@@ -37,6 +27,7 @@ MACHINE_CONTROLLER_MANAGER_DEPLOYMENT_NAME := machine-controller-manager
 # Rules for running helper scripts
 #########################################
 
+-include .env
 include hack/tools.mk
 
 .PHONY: rename-provider
@@ -93,6 +84,19 @@ update-dependencies:
 #########################################
 # Rules for testing
 #########################################
+
+.PHONY: test-setup
+test-setup:
+	@echo "enter project name"; \
+	read PROJECT; \
+	echo "enter control-cluster name"; \
+	read CONTROL_CLUSTER; \
+	echo "enter target-cluster name"; \
+	read TARGET_CLUSTER; \
+	echo "enter cluster provider(gcp|aws|azure|vsphere|openstack|alicloud|metal|equinix-metal)"; \
+	read PROVIDER; \
+	./hack/test_local_setup.sh --control-cluster $$CONTROL_CLUSTER --target-cluster $$TARGET_CLUSTER --project $$PROJECT --provider $$PROVIDER
+
 
 .PHONY: test-unit
 test-unit:

--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+-include .env
+include hack/tools.mk
+
 BINARY_PATH         := bin/
 COVERPROFILE        := test/output/coverprofile.out
 IMAGE_REPOSITORY    := eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-aws
 IMAGE_TAG           := $(shell cat VERSION)
 PROVIDER_NAME       := AWS
 PROJECT_NAME        := gardener
-
 LEADER_ELECT 	    := "true"
 # If Integration Test Suite is to be run locally against clusters then export the below variable
 # with MCM deployment name in the cluster
@@ -26,9 +28,6 @@ MACHINE_CONTROLLER_MANAGER_DEPLOYMENT_NAME := machine-controller-manager
 #########################################
 # Rules for running helper scripts
 #########################################
-
--include .env
-include hack/tools.mk
 
 .PHONY: rename-provider
 rename-provider:

--- a/Makefile
+++ b/Makefile
@@ -85,19 +85,6 @@ update-dependencies:
 # Rules for testing
 #########################################
 
-.PHONY: test-setup
-test-setup:
-	@echo "enter project name"; \
-	read PROJECT; \
-	echo "enter control-cluster name"; \
-	read CONTROL_CLUSTER; \
-	echo "enter target-cluster name"; \
-	read TARGET_CLUSTER; \
-	echo "enter cluster provider(gcp|aws|azure|vsphere|openstack|alicloud|metal|equinix-metal)"; \
-	read PROVIDER; \
-	./hack/test_local_setup.sh --control-cluster $$CONTROL_CLUSTER --target-cluster $$TARGET_CLUSTER --project $$PROJECT --provider $$PROVIDER
-
-
 .PHONY: test-unit
 test-unit:
 	@SKIP_INTEGRATION_TESTS=X .ci/test

--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -21,9 +21,9 @@ GO_ADD_LICENSE_VERSION ?= latest
 
 export TOOLS_BIN_DIR := $(TOOLS_BIN_DIR)
 export PATH := $(abspath $(TOOLS_BIN_DIR)):$(PATH)
-$(info "TOOLS_BIN_DIR from tools.mk", $(TOOLS_BIN_DIR))
-$(info "TOOLS_DIR from tools.mk", $(TOOLS_DIR))
-$(info "PATH from tools.mk", $(PATH))
+#$(info "TOOLS_BIN_DIR from tools.mk", $(TOOLS_BIN_DIR))
+#$(info "TOOLS_DIR from tools.mk", $(TOOLS_DIR))
+#$(info "PATH from tools.mk", $(PATH))
 
 #########################################
 # Tools                                 #


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes the unwanted logs printed after running make command and moves the dynamic content of Makefile to .env file.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/machine-controller-manager/issues/846 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
