### PR TITLE
Add support for setting CpuOptions on AWS instances

### DIFF
--- a/pkg/aws/apis/aws_provider_spec.go
+++ b/pkg/aws/apis/aws_provider_spec.go
@@ -97,6 +97,9 @@ type AWSProviderSpec struct {
 
 	// InstanceMetadataOptions contains configuration for controlling access to the metadata API.
 	InstanceMetadataOptions *InstanceMetadataOptions `json:"instanceMetadataOptions,omitempty"`
+
+	// CPUOptions contains detailed configuration for the number of cores and threads for the instance.
+	CPUOptions *CPUOptions `json:"cpuOptions,omitempty"`
 }
 
 // AWSBlockDeviceMappingSpec stores info about AWS block device mappings
@@ -261,4 +264,13 @@ type InstanceMetadataOptions struct {
 	HTTPPutResponseHopLimit *int64 `json:"httpPutResponseHopLimit,omitempty"`
 	// HTTPTokens enforces the use of metadata v2 API.
 	HTTPTokens *string `json:"httpTokens,omitempty"`
+}
+
+// CPUOptions contains detailed configuration for the number of cores and threads for the instance.
+type CPUOptions struct {
+	// CoreCount specifies the number of CPU cores per instance.
+	CoreCount *int64 `json:"coreCount"`
+
+	// ThreadsPerCore sets the number of threads per core. Must be either '1' (disable multi-threading) or '2'.
+	ThreadsPerCore *int64 `json:"threadsPerCore"`
 }

--- a/pkg/aws/apis/validation/validation.go
+++ b/pkg/aws/apis/validation/validation.go
@@ -49,6 +49,7 @@ func ValidateAWSProviderSpec(spec *awsapi.AWSProviderSpec, secret *corev1.Secret
 	allErrs = append(allErrs, ValidateSecret(secret, field.NewPath("secretRef"))...)
 	allErrs = append(allErrs, validateSpecTags(spec.Tags, fldPath.Child("tags"))...)
 	allErrs = append(allErrs, validateInstanceMetadata(spec.InstanceMetadataOptions, fldPath.Child("instanceMetadata"))...)
+	allErrs = append(allErrs, validateCPUOptions(spec.CPUOptions, fldPath.Child(("cpuOptions")))...)
 
 	return allErrs
 }
@@ -199,6 +200,27 @@ func validateInstanceMetadata(metadata *awsapi.InstanceMetadataOptions, fldPath 
 
 	if metadata.HTTPTokens != nil {
 		allErrs = append(allErrs, validateStringValues(fldPath.Child("httpTokens"), *metadata.HTTPTokens, []string{awsapi.HTTPTokensRequired, awsapi.HTTPTokensOptional})...)
+	}
+
+	return allErrs
+}
+
+func validateCPUOptions(cpuOptions *awsapi.CPUOptions, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if cpuOptions == nil {
+		return allErrs
+	}
+
+	if cpuOptions.CoreCount == nil {
+		allErrs = append(allErrs, field.Required(fldPath.Child("coreCount"), "CoreCount is required"))
+	}
+
+	if cpuOptions.ThreadsPerCore == nil {
+		allErrs = append(allErrs, field.Required(fldPath.Child("threadsPerCore"), "ThreadsPerCore is required"))
+	}
+
+	if threadsPerCore := *cpuOptions.ThreadsPerCore; threadsPerCore > 2 || threadsPerCore < 1 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("threadsPerCore"), threadsPerCore, "ThreadsPerCore must be either '1' or '2'"))
 	}
 
 	return allErrs

--- a/pkg/aws/core.go
+++ b/pkg/aws/core.go
@@ -10,9 +10,10 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/gardener/machine-controller-manager-provider-aws/pkg/instrument"
 	"strings"
 	"time"
+
+	"github.com/gardener/machine-controller-manager-provider-aws/pkg/instrument"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -179,6 +180,13 @@ func (d *Driver) CreateMachine(ctx context.Context, req *driver.CreateMachineReq
 
 	if providerSpec.KeyName != nil && len(*providerSpec.KeyName) > 0 {
 		inputConfig.KeyName = aws.String(*providerSpec.KeyName)
+	}
+
+	if cpuOptions := providerSpec.CPUOptions; cpuOptions != nil {
+		inputConfig.CpuOptions = &ec2.CpuOptionsRequest{
+			CoreCount:      cpuOptions.CoreCount,
+			ThreadsPerCore: cpuOptions.ThreadsPerCore,
+		}
 	}
 
 	// Set the AWS Capacity Reservation target. Using an 'open' preference means that if the reservation is not found, then


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support for setting CPU Options (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-specify-cpu-options.html) on instances.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
It is now possible to specify CPU options for AWS instances.
```
