### PR TITLE
Replace goling with golangci-lint

### DIFF
--- a/.ci/check
+++ b/.ci/check
@@ -21,42 +21,28 @@ else
   export SOURCE_PATH="$(${READLINK_BIN} -f "${SOURCE_PATH}")"
 fi
 
-# The `go <cmd>` commands requires to see the target repository to be part of a
-# Go workspace. Thus, if we are not yet in a Go workspace, let's create one
-# temporarily by using symbolic links.
-if [[ "${SOURCE_PATH}" != *"src/github.com/gardener/machine-controller-manager-provider-aws" ]]; then
-  SOURCE_SYMLINK_PATH="${SOURCE_PATH}/tmp/src/github.com/gardener/machine-controller-manager-provider-aws"
-  if [[ -d "${SOURCE_PATH}/tmp" ]]; then
-    rm -rf "${SOURCE_PATH}/tmp"
-  fi
-  mkdir -p "${SOURCE_PATH}/tmp/src/github.com/gardener"
-  ln -s "${SOURCE_PATH}" "${SOURCE_SYMLINK_PATH}"
-  cd "${SOURCE_SYMLINK_PATH}"
+export GOBIN="${SOURCE_PATH}/tmp/bin"
+export PATH="${GOBIN}:${PATH}"
 
-  export GOPATH="${SOURCE_PATH}/tmp"
-  export GOBIN="${SOURCE_PATH}/tmp/bin"
-  export PATH="${GOBIN}:${PATH}"
+# Install golangci-lint (linting tool).
+if [[ -z "${GOLANGCI_LINT_VERSION}" ]]; then
+  export GOLANGCI_LINT_VERSION=v1.57.1
 fi
-
-# Install Golint (linting tool).
-if ! which golint 1>/dev/null; then
-  echo -n "Installing golint... "
-  GO111MODULE=off go get -u golang.org/x/lint/golint
-  echo "done."
-fi
+echo "Fetching golangci-lint tool"
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@"${GOLANGCI_LINT_VERSION}"
+echo "Successfully fetched golangci-lint"
+golangci-lint version
 
 ###############################################################################
 PACKAGES="$(go list -e ./... | grep -vE '/tmp/')"
 LINT_FOLDERS="$(echo ${PACKAGES} | sed "s|github.com/gardener/machine-controller-manager-provider-aws|.|g")"
 
-# Execute static code checks.
-go vet ${PACKAGES}
+echo "Executing golangci-lint"
+# golangci-lint can't be run from outside the directory
+(cd ${SOURCE_PATH} && golangci-lint run -c .golangci.yaml --timeout 10m)
 
-# Execute automatic code formatting directive.
-go fmt ${PACKAGES}
-
-# Execute lint checks.
-for package in ${LINT_FOLDERS}; do
-    golint -set_exit_status $(find $package -maxdepth 1 -name "*.go" | grep -vE 'zz_generated|_test.go')
-done
-echo "Check script has passed successfully"
+## Execute static code checks.
+#go vet ${PACKAGES}
+#
+## Execute automatic code formatting directive.
+#go fmt ${PACKAGES}

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,49 @@
+run:
+  concurrency: 4
+  timeout: 10m
+
+linters:
+  disable:
+    - unused
+  enable:
+    - revive
+    - loggercheck
+
+issues:
+  exclude-use-default: false
+  exclude:
+    # errcheck: Almost all programs ignore errors on these functions and in most cases it's ok
+    - Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*printf?|os\.(Un)?Setenv). is not checked
+    # revive:
+    - var-naming # ((var|const|struct field|func) .* should be .*
+    - dot-imports # should not use dot imports
+    - package-comments # package comment should be of the form
+    - unexported-return # exported func .* returns unexported type .*, which can be annoying to use
+    - indent-error-flow # if block ends with a return statement, so drop this else and outdent its block
+    - "exported: (type|func) name will be used as .* by other packages, and that stutters;"
+    # typecheck:
+    - "undeclared name: `.*`"
+    - "\".*\" imported but not used"
+    # allow non-capitalized messages if they start with technical terms
+    - "structured logging message should be capitalized: \"garden(er-apiserver|er-controller-manager|er-admission-controller|er-operator|er-resource-manager|let)"
+  exclude-rules:
+    - linters:
+        - staticcheck
+      text: "SA1019:" # Excludes messages where deprecated variables are used
+
+  exclude-files:
+    - "zz_generated\\..*\\.go$"
+
+linters-settings:
+  revive:
+    rules:
+      - name: duplicated-imports
+      - name: unused-parameter
+      - name: unreachable-code
+      - name: context-as-argument
+      - name: early-return
+      - name: exported
+  loggercheck:
+    no-printf-like: true
+    logr: true
+    zap: true

--- a/pkg/aws/apis/validation/validation.go
+++ b/pkg/aws/apis/validation/validation.go
@@ -98,11 +98,7 @@ func validateBlockDevices(blockDevices []awsapi.AWSBlockDeviceMappingSpec, fldPa
 			allErrs = append(allErrs, field.Invalid(idxPath.Child("deviceName"), disk.DeviceName, utilvalidation.RegexError(fmt.Sprintf("Device name given: %s does not match the expected pattern", disk.DeviceName), awsapi.DataDeviceNameFormat)))
 		}
 
-		if _, keyExist := deviceNames[disk.DeviceName]; keyExist {
-			deviceNames[disk.DeviceName]++
-		} else {
-			deviceNames[disk.DeviceName] = 1
-		}
+		deviceNames[disk.DeviceName] += 1
 
 		if !slices.Contains(awsapi.ValidVolumeTypes, disk.Ebs.VolumeType) {
 			allErrs = append(allErrs, field.Required(idxPath.Child("ebs.volumeType"), fmt.Sprintf("Please mention a valid EBS volume type: %v", awsapi.ValidVolumeTypes)))

--- a/pkg/aws/core.go
+++ b/pkg/aws/core.go
@@ -61,7 +61,7 @@ func NewAWSDriver(spi spi.SessionProviderInterface) driver.Driver {
 }
 
 // CreateMachine handles a machine creation request
-func (d *Driver) CreateMachine(ctx context.Context, req *driver.CreateMachineRequest) (resp *driver.CreateMachineResponse, err error) {
+func (d *Driver) CreateMachine(_ context.Context, req *driver.CreateMachineRequest) (resp *driver.CreateMachineResponse, err error) {
 	defer instrument.DriverAPIMetricRecorderFn(createMachineOperationLabel, &err)()
 
 	var (
@@ -254,7 +254,7 @@ func (d *Driver) CreateMachine(ctx context.Context, req *driver.CreateMachineReq
 // InitializeMachine should handle post-creation, one-time VM instance initialization operations. (Ex: Like setting up special network config, etc)
 // The AWS Provider leverages this method to perform disabling of source destination checks for NAT instances.
 // See [driver.Driver.InitializeMachine] for further information
-func (d *Driver) InitializeMachine(ctx context.Context, request *driver.InitializeMachineRequest) (*driver.InitializeMachineResponse, error) {
+func (d *Driver) InitializeMachine(_ context.Context, request *driver.InitializeMachineRequest) (*driver.InitializeMachineResponse, error) {
 	providerSpec, err := decodeProviderSpecAndSecret(request.MachineClass, request.Secret)
 	if err != nil {
 		return nil, err
@@ -322,7 +322,7 @@ func getPlacementObj(req *driver.CreateMachineRequest) (placementobj *ec2.Placem
 }
 
 // DeleteMachine handles a machine deletion request
-func (d *Driver) DeleteMachine(ctx context.Context, req *driver.DeleteMachineRequest) (resp *driver.DeleteMachineResponse, err error) {
+func (d *Driver) DeleteMachine(_ context.Context, req *driver.DeleteMachineRequest) (resp *driver.DeleteMachineResponse, err error) {
 	defer instrument.DriverAPIMetricRecorderFn(deleteMachineOperationLabel, &err)()
 
 	var (
@@ -393,7 +393,7 @@ func (d *Driver) DeleteMachine(ctx context.Context, req *driver.DeleteMachineReq
 }
 
 // GetMachineStatus handles a machine get status request
-func (d *Driver) GetMachineStatus(ctx context.Context, req *driver.GetMachineStatusRequest) (resp *driver.GetMachineStatusResponse, err error) {
+func (d *Driver) GetMachineStatus(_ context.Context, req *driver.GetMachineStatusRequest) (resp *driver.GetMachineStatusResponse, err error) {
 	defer instrument.DriverAPIMetricRecorderFn(getMachineStatusOperationLabel, &err)()
 
 	var (
@@ -451,7 +451,7 @@ func (d *Driver) GetMachineStatus(ctx context.Context, req *driver.GetMachineSta
 }
 
 // ListMachines lists all the machines possibly created by a machineClass
-func (d *Driver) ListMachines(ctx context.Context, req *driver.ListMachinesRequest) (resp *driver.ListMachinesResponse, err error) {
+func (d *Driver) ListMachines(_ context.Context, req *driver.ListMachinesRequest) (resp *driver.ListMachinesResponse, err error) {
 	defer instrument.DriverAPIMetricRecorderFn(listMachinesOperationLabel, &err)()
 
 	var (
@@ -545,7 +545,7 @@ func (d *Driver) ListMachines(ctx context.Context, req *driver.ListMachinesReque
 }
 
 // GetVolumeIDs returns a list of Volume IDs for all PV Specs for whom a provider volume was found
-func (d *Driver) GetVolumeIDs(ctx context.Context, req *driver.GetVolumeIDsRequest) (resp *driver.GetVolumeIDsResponse, err error) {
+func (d *Driver) GetVolumeIDs(_ context.Context, req *driver.GetVolumeIDsRequest) (resp *driver.GetVolumeIDsResponse, err error) {
 	defer instrument.DriverAPIMetricRecorderFn(getVolumeIDsOperationLabel, &err)()
 
 	var (

--- a/pkg/aws/core_util.go
+++ b/pkg/aws/core_util.go
@@ -139,12 +139,10 @@ func (d *Driver) getInstancesFromMachineName(machineName string, providerSpec *a
 	}
 
 	for _, reservation := range runResult.Reservations {
-		for _, instance := range reservation.Instances {
-			instances = append(instances, instance)
-		}
+		instances = append(instances, reservation.Instances...)
 	}
 	if len(instances) == 0 {
-		errMessage := fmt.Sprintf("AWS plugin is returning no VM instances backing this machine object")
+		errMessage := "AWS plugin is returning no VM instances backing this machine object"
 		return nil, status.Error(codes.NotFound, errMessage)
 	}
 

--- a/pkg/aws/util.go
+++ b/pkg/aws/util.go
@@ -96,7 +96,7 @@ func getIntPtrForString(s string) *int64 {
 	return &num
 }
 
-func retryWithExponentialBackOff(operation backoff.Operation, maxElapsedTime time.Duration) error {
+func retryWithExponentialBackOff(operation backoff.Operation, _ time.Duration) error {
 	expBackOffObj := backoff.NewExponentialBackOff()
 	expBackOffObj.MaxElapsedTime = maxElapsedTimeInBackoff
 	if err := backoff.Retry(operation, expBackOffObj); err != nil {

--- a/pkg/instrument/instrument_test.go
+++ b/pkg/instrument/instrument_test.go
@@ -38,7 +38,7 @@ func TestDriverAPIMetricRecorderFn(t *testing.T) {
 	reg := prometheus.NewRegistry()
 	g.Expect(reg.Register(metrics.DriverFailedAPIRequests)).To(Succeed())
 	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(_ *testing.T) {
 			defer metrics.DriverFailedAPIRequests.Reset()
 			_ = deferredMetricsRecorderInvoker(tc.err != nil, isStatusErr(tc.err), DriverAPIMetricRecorderFn)
 			if tc.err != nil {

--- a/pkg/mockclient/mockclient.go
+++ b/pkg/mockclient/mockclient.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/session"
 	awssession "github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
@@ -64,7 +63,7 @@ type MockPluginSPIImpl struct {
 }
 
 // NewSession starts a new AWS session
-func (ms *MockPluginSPIImpl) NewSession(secret *corev1.Secret, region string) (*awssession.Session, error) {
+func (ms *MockPluginSPIImpl) NewSession(_ *corev1.Secret, region string) (*awssession.Session, error) {
 	if region == FailAtRegion {
 		return nil, AWSInvalidRegionError
 	}
@@ -72,7 +71,7 @@ func (ms *MockPluginSPIImpl) NewSession(secret *corev1.Secret, region string) (*
 }
 
 // NewEC2API Returns a EC2API object
-func (ms *MockPluginSPIImpl) NewEC2API(session *session.Session) ec2iface.EC2API {
+func (ms *MockPluginSPIImpl) NewEC2API(_ *awssession.Session) ec2iface.EC2API {
 	return &MockEC2Client{
 		FakeInstances: &ms.FakeInstances,
 	}
@@ -273,7 +272,6 @@ func (ms *MockEC2Client) StopInstances(input *ec2.StopInstancesInput) (*ec2.Stop
 				// Do not append InstanceID, there by removing it
 				found = true
 				desiredInstance = instance
-			} else {
 			}
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR replaces the deprecated `golint` with `golangci-lint` 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Replaced linter to use golangci-lint instead of the older golint
```
