### PR TITLE
Readd go vet and go fmt checks that were erroneously removed

### DIFF
--- a/.ci/check
+++ b/.ci/check
@@ -34,15 +34,19 @@ echo "Successfully fetched golangci-lint"
 golangci-lint version
 
 ###############################################################################
+cd ${SOURCE_PATH}
+
 PACKAGES="$(go list -e ./... | grep -vE '/tmp/')"
 LINT_FOLDERS="$(echo ${PACKAGES} | sed "s|github.com/gardener/machine-controller-manager-provider-aws|.|g")"
 
-echo "Executing golangci-lint"
+# Execute static code checks.
+echo "Running go vet..."
+go vet ${PACKAGES}
+
+# Execute automatic code formatting directive.
+echo "Running go vet..."
+go fmt ${PACKAGES}
+
+echo "Executing golangci-lint..."
 # golangci-lint can't be run from outside the directory
 (cd ${SOURCE_PATH} && golangci-lint run -c .golangci.yaml --timeout 10m)
-
-## Execute static code checks.
-#go vet ${PACKAGES}
-#
-## Execute automatic code formatting directive.
-#go fmt ${PACKAGES}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR reverts a change that erroneously removed `go vet` and `go fmt` checks

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
