### PR TITLE
fix component descriptor for pipeline definitions

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -22,7 +22,9 @@ machine-controller-manager-provider-aws:
       <<: *steps_anchor
       traits:
         <<: *version_anchor
-        component_descriptor: ~
+        component_descriptor:
+          ocm_repository_mappings:
+            - repository: europe-docker.pkg.dev/gardener-project/releases
         draft_release: ~
         publish:
           dockerimages: &default_images


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix component descriptor in pipeline definitions to check latest image in `europe-docker.pkg.dev/gardener-project/snapshots` instead of gcr

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
