### PR TITLE
Use `ProviderID` as a fallback for fetching the VM, `InitializeMachine` returns `Uninitialized` error code if VM is not found.

### DIFF
--- a/pkg/aws/core.go
+++ b/pkg/aws/core.go
@@ -262,8 +262,7 @@ func (d *Driver) InitializeMachine(_ context.Context, request *driver.Initialize
 	instances, err := d.getMatchingInstancesForMachine(request.Machine, providerSpec, request.Secret)
 	if err != nil {
 		if isNotFoundError(err) {
-			//TODO check if level is correct, and if log is appropriate
-			klog.V(2).Infof("Could not retrieve instances for machine %s from provider", request.Machine.Name)
+			klog.Errorf("Could not get matching instance for uninitialized machine %q from provider: %s", request.Machine.Name, err)
 			return nil, status.Error(codes.Uninitialized, err.Error())
 		}
 		return nil, err

--- a/pkg/aws/core.go
+++ b/pkg/aws/core.go
@@ -74,7 +74,7 @@ func (d *Driver) CreateMachine(_ context.Context, req *driver.CreateMachineReque
 
 	// Check if the MachineClass is for the supported cloud provider
 	if req.MachineClass.Provider != ProviderAWS {
-		err = fmt.Errorf("Requested for Provider '%s', we only support '%s'", req.MachineClass.Provider, ProviderAWS)
+		err = fmt.Errorf("requested for Provider '%s', we only support '%s'", req.MachineClass.Provider, ProviderAWS)
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
@@ -259,7 +259,11 @@ func (d *Driver) InitializeMachine(_ context.Context, request *driver.Initialize
 	if err != nil {
 		return nil, err
 	}
-	instances, err := d.getMatchingInstancesForMachine(request.Machine, providerSpec, request.Secret)
+	svc, err := d.createSVC(request.Secret, providerSpec.Region)
+	if err != nil {
+		return nil, status.Error(codes.Uninitialized, err.Error())
+	}
+	instances, err := d.getMatchingInstancesForMachine(request.Machine, svc, providerSpec.Tags)
 	if err != nil {
 		if isNotFoundError(err) {
 			klog.Errorf("Could not get matching instance for uninitialized machine %q from provider: %s", request.Machine.Name, err)
@@ -269,10 +273,6 @@ func (d *Driver) InitializeMachine(_ context.Context, request *driver.Initialize
 	}
 	targetInstance := instances[0]
 	providerID := encodeInstanceID(providerSpec.Region, *targetInstance.InstanceId)
-	svc, err := d.createSVC(request.Secret, providerSpec.Region)
-	if err != nil {
-		return nil, status.Error(codes.Uninitialized, err.Error())
-	}
 	// if SrcAnDstCheckEnabled is false then disable the SrcAndDestCheck on running NAT instance
 	if providerSpec.SrcAndDstChecksEnabled != nil && !*providerSpec.SrcAndDstChecksEnabled && *targetInstance.SourceDestCheck {
 		klog.V(3).Infof("Disabling SourceDestCheck on VM %q associated with machine %s", providerID, request.Machine.Name)
@@ -334,7 +334,7 @@ func (d *Driver) DeleteMachine(_ context.Context, req *driver.DeleteMachineReque
 
 	// Check if the MachineClass is for the supported cloud provider
 	if req.MachineClass.Provider != ProviderAWS {
-		err = fmt.Errorf("Requested for Provider '%s', we only support '%s'", req.MachineClass.Provider, ProviderAWS)
+		err = fmt.Errorf("requested for Provider '%s', we only support '%s'", req.MachineClass.Provider, ProviderAWS)
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
@@ -403,20 +403,23 @@ func (d *Driver) GetMachineStatus(_ context.Context, req *driver.GetMachineStatu
 
 	// Check if the MachineClass is for the supported cloud provider
 	if req.MachineClass.Provider != ProviderAWS {
-		err = fmt.Errorf("Requested for Provider '%s', we only support '%s'", req.MachineClass.Provider, ProviderAWS)
+		err = fmt.Errorf("requested for Provider '%s', we only support '%s'", req.MachineClass.Provider, ProviderAWS)
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	// Log messages to track start and end of request
 	klog.V(3).Infof("Get request has been recieved for %q", req.Machine.Name)
-
 	providerSpec, err := decodeProviderSpecAndSecret(machineClass, secret)
 	if err != nil {
 		return nil, err
 	}
 
-	instances, err := d.getMatchingInstancesForMachine(req.Machine, providerSpec, secret)
+	svc, err := d.createSVC(secret, providerSpec.Region)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
 
+	instances, err := d.getMatchingInstancesForMachine(req.Machine, svc, providerSpec.Tags)
 	if err != nil {
 		return nil, err
 	} else if len(instances) > 1 {
@@ -430,6 +433,10 @@ func (d *Driver) GetMachineStatus(_ context.Context, req *driver.GetMachineStatu
 	}
 
 	requiredInstance := instances[0]
+	response := &driver.GetMachineStatusResponse{
+		NodeName:   *requiredInstance.PrivateDnsName,
+		ProviderID: encodeInstanceID(providerSpec.Region, *requiredInstance.InstanceId),
+	}
 
 	// if SrcAnDstCheckEnabled is false then check attribute on instance and return Uninitialized error if not matching.
 	if providerSpec.SrcAndDstChecksEnabled != nil && !*providerSpec.SrcAndDstChecksEnabled {
@@ -437,13 +444,8 @@ func (d *Driver) GetMachineStatus(_ context.Context, req *driver.GetMachineStatu
 			msg := fmt.Sprintf("VM %q associated with machine %q has SourceDestCheck=%t despite providerSpec.SrcAndDstChecksEnabled=%t",
 				*requiredInstance.InstanceId, req.Machine.Name, *requiredInstance.SourceDestCheck, *providerSpec.SrcAndDstChecksEnabled)
 			klog.Warning(msg)
-			return nil, status.Error(codes.Uninitialized, msg)
+			return response, status.Error(codes.Uninitialized, msg)
 		}
-	}
-
-	response := &driver.GetMachineStatusResponse{
-		NodeName:   *requiredInstance.PrivateDnsName,
-		ProviderID: encodeInstanceID(providerSpec.Region, *requiredInstance.InstanceId),
 	}
 
 	klog.V(3).Infof("Machine get request has been processed successfully for %q", req.Machine.Name)
@@ -461,7 +463,7 @@ func (d *Driver) ListMachines(_ context.Context, req *driver.ListMachinesRequest
 
 	// Check if the MachineClass is for the supported cloud provider
 	if req.MachineClass.Provider != ProviderAWS {
-		err = fmt.Errorf("Requested for Provider '%s', we only support '%s'", req.MachineClass.Provider, ProviderAWS)
+		err = fmt.Errorf("requested for Provider '%s', we only support '%s'", req.MachineClass.Provider, ProviderAWS)
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 

--- a/pkg/aws/core_test.go
+++ b/pkg/aws/core_test.go
@@ -23,11 +23,11 @@ import (
 )
 
 const (
-	awsAccessKeyIDIsMissing               = "machine codes error: code = [InvalidArgument] message = [Error while validating ProviderSpec secretRef.AWSAccessKeyID: Required value: Mention atleast providerAccessKeyId or accessKeyID]"
-	awsSecretAccessKeyIsMissing           = "machine codes error: code = [InvalidArgument] message = [Error while validating ProviderSpec secretRef.AWSSecretAccessKey: Required value: Mention atleast providerSecretAccessKey or secretAccessKey]"
-	awsSecretAccessKeyNUserDataAreMissing = "machine codes error: code = [InvalidArgument] message = [Error while validating ProviderSpec [secretRef.AWSSecretAccessKey: Required value: Mention atleast providerSecretAccessKey or secretAccessKey, secretRef.userData: Required value: Mention userData]]"
-	regionNAMIMissing                     = "machine codes error: code = [InvalidArgument] message = [Error while validating ProviderSpec [providerSpec.ami: Required value: AMI is required, providerSpec.region: Required value: Region is required]]"
-	userDataIsMissing                     = "machine codes error: code = [InvalidArgument] message = [Error while validating ProviderSpec secretRef.userData: Required value: Mention userData]"
+	awsAccessKeyIDIsMissing               = "machine codes error: code = [InvalidArgument] message = [error while validating ProviderSpec secretRef.AWSAccessKeyID: Required value: Mention atleast providerAccessKeyId or accessKeyID]"
+	awsSecretAccessKeyIsMissing           = "machine codes error: code = [InvalidArgument] message = [error while validating ProviderSpec secretRef.AWSSecretAccessKey: Required value: Mention atleast providerSecretAccessKey or secretAccessKey]"
+	awsSecretAccessKeyNUserDataAreMissing = "machine codes error: code = [InvalidArgument] message = [error while validating ProviderSpec [secretRef.AWSSecretAccessKey: Required value: Mention atleast providerSecretAccessKey or secretAccessKey, secretRef.userData: Required value: Mention userData]]"
+	regionNAMIMissing                     = "machine codes error: code = [InvalidArgument] message = [error while validating ProviderSpec [providerSpec.ami: Required value: AMI is required, providerSpec.region: Required value: Region is required]]"
+	userDataIsMissing                     = "machine codes error: code = [InvalidArgument] message = [error while validating ProviderSpec secretRef.userData: Required value: Mention userData]"
 )
 
 var _ = Describe("MachineServer", func() {
@@ -114,7 +114,7 @@ var _ = Describe("MachineServer", func() {
 				},
 				expect: expect{
 					errToHaveOccurred: true,
-					errMessage:        "machine codes error: code = [InvalidArgument] message = [Requested for Provider 'azure', we only support 'AWS']",
+					errMessage:        "machine codes error: code = [InvalidArgument] message = [requested for Provider 'azure', we only support 'AWS']",
 				},
 			}),
 			Entry("Machine creation request with IAM ARN", &data{
@@ -191,7 +191,7 @@ var _ = Describe("MachineServer", func() {
 				},
 				expect: expect{
 					errToHaveOccurred: true,
-					errMessage:        "machine codes error: code = [InvalidArgument] message = [Error while validating ProviderSpec providerSpec.capacityReservation: Required value: CapacityReservationResourceGroupArn or CapacityReservationId are optional but only one should be used]",
+					errMessage:        "machine codes error: code = [InvalidArgument] message = [error while validating ProviderSpec providerSpec.capacityReservation: Required value: CapacityReservationResourceGroupArn or CapacityReservationId are optional but only one should be used]",
 				},
 			}),
 			Entry("Machine creation request for an AWS Capacity Reservation Group with capacityReservationPreference only", &data{
@@ -681,7 +681,7 @@ var _ = Describe("MachineServer", func() {
 				},
 				expect: expect{
 					errToHaveOccurred: true,
-					errMessage:        "machine codes error: code = [InvalidArgument] message = [Requested for Provider 'azure', we only support 'AWS']",
+					errMessage:        "machine codes error: code = [InvalidArgument] message = [requested for Provider 'azure', we only support 'AWS']",
 				},
 			}),
 			Entry("providerAccessKeyId missing for secret", &data{
@@ -891,7 +891,7 @@ var _ = Describe("MachineServer", func() {
 				},
 				expect: expect{
 					errToHaveOccurred: true,
-					errMessage:        "machine codes error: code = [InvalidArgument] message = [Requested for Provider 'azure', we only support 'AWS']",
+					errMessage:        "machine codes error: code = [InvalidArgument] message = [requested for Provider 'azure', we only support 'AWS']",
 				},
 			}),
 			Entry("providerAccessKeyId missing for secret", &data{
@@ -1093,7 +1093,7 @@ var _ = Describe("MachineServer", func() {
 				},
 				expect: expect{
 					errToHaveOccurred: true,
-					errMessage:        "machine codes error: code = [InvalidArgument] message = [Requested for Provider 'azure', we only support 'AWS']",
+					errMessage:        "machine codes error: code = [InvalidArgument] message = [requested for Provider 'azure', we only support 'AWS']",
 				},
 			}),
 			Entry("Unexpected end of JSON input", &data{
@@ -1198,7 +1198,7 @@ var _ = Describe("MachineServer", func() {
 				},
 				expect: expect{
 					errToHaveOccurred: true,
-					errMessage:        "machine codes error: code = [InvalidArgument] message = [Error while validating ProviderSpec providerSpec.tags[]: Required value: Tag required of the form kubernetes.io/cluster/****]",
+					errMessage:        "machine codes error: code = [InvalidArgument] message = [error while validating ProviderSpec providerSpec.tags[]: Required value: Tag required of the form kubernetes.io/cluster/****]",
 				},
 			}),
 			Entry("Cloud provider returned error while describing instance", &data{

--- a/pkg/aws/core_util.go
+++ b/pkg/aws/core_util.go
@@ -141,18 +141,17 @@ func (d *Driver) getMatchingInstancesForMachine(machine *v1alpha1.Machine, provi
 	runResult, err := getMachineInstancesByTagsAndStatus(svc, machine.Name, clusterName, nodeRole)
 	//if getMachineInstancesByTagsAndStatus returns an error, try fetching matching instances using getInstanceByID()
 	if err != nil {
-		if machine.Spec.ProviderID != "" {
-			_, instanceID, err := decodeRegionAndInstanceID(machine.Spec.ProviderID)
-			if err != nil {
-				return nil, status.Error(codes.InvalidArgument, err.Error())
-			}
-			runResult, err = getInstanceByID(svc, instanceID)
-			if err != nil {
-				klog.Errorf("AWS plugin is returning error while describe instances request is sent: %s", err)
-				return nil, status.Error(codes.Internal, err.Error())
-			}
-		} else {
+		if machine.Spec.ProviderID == "" {
 			return nil, status.Error(codes.NotFound, "ProviderID is blank")
+		}
+		_, instanceID, err := decodeRegionAndInstanceID(machine.Spec.ProviderID)
+		if err != nil {
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
+		runResult, err = getInstanceByID(svc, instanceID)
+		if err != nil {
+			klog.Errorf("AWS plugin is returning error while describe instances request is sent: %s", err)
+			return nil, status.Error(codes.Internal, err.Error())
 		}
 	}
 	for _, reservation := range runResult.Reservations {

--- a/pkg/aws/core_util.go
+++ b/pkg/aws/core_util.go
@@ -141,14 +141,18 @@ func (d *Driver) getMatchingInstancesForMachine(machine *v1alpha1.Machine, provi
 	runResult, err := getMachineInstancesByTagsAndStatus(svc, machine.Name, clusterName, nodeRole)
 	//if getMachineInstancesByTagsAndStatus returns an error, try fetching matching instances using getInstanceByID()
 	if err != nil {
-		_, instanceID, err := decodeRegionAndInstanceID(machine.Spec.ProviderID)
-		if err != nil {
-			return nil, status.Error(codes.InvalidArgument, err.Error())
-		}
-		runResult, err = getInstanceByID(svc, instanceID)
-		if err != nil {
-			klog.Errorf("AWS plugin is returning error while describe instances request is sent: %s", err)
-			return nil, status.Error(codes.Internal, err.Error())
+		if machine.Spec.ProviderID != "" {
+			_, instanceID, err := decodeRegionAndInstanceID(machine.Spec.ProviderID)
+			if err != nil {
+				return nil, status.Error(codes.InvalidArgument, err.Error())
+			}
+			runResult, err = getInstanceByID(svc, instanceID)
+			if err != nil {
+				klog.Errorf("AWS plugin is returning error while describe instances request is sent: %s", err)
+				return nil, status.Error(codes.Internal, err.Error())
+			}
+		} else {
+			return nil, status.Error(codes.NotFound, "ProviderID is blank")
 		}
 	}
 	for _, reservation := range runResult.Reservations {

--- a/pkg/aws/core_util.go
+++ b/pkg/aws/core_util.go
@@ -52,7 +52,7 @@ func decodeProviderSpecAndSecret(machineClass *v1alpha1.MachineClass, secret *co
 	// Validate the Spec and Secrets
 	validationErr := validation.ValidateAWSProviderSpec(providerSpec, secret, field.NewPath("providerSpec"))
 	if validationErr.ToAggregate() != nil && len(validationErr.ToAggregate().Errors()) > 0 {
-		err = fmt.Errorf("Error while validating ProviderSpec %v", validationErr.ToAggregate().Error())
+		err = fmt.Errorf("error while validating ProviderSpec %v", validationErr.ToAggregate().Error())
 		klog.V(2).Infof("Validation of AWSMachineClass failed %s", err)
 
 		return nil, status.Error(codes.InvalidArgument, err.Error())
@@ -137,12 +137,8 @@ func getMachineInstancesByTagsAndStatus(svc ec2iface.EC2API, machineName string,
 }
 
 // getMatchingInstancesForMachine extracts AWS Instance object for a given machine
-func (d *Driver) getMatchingInstancesForMachine(machine *v1alpha1.Machine, providerSpec *api.AWSProviderSpec, secret *corev1.Secret) (instances []*ec2.Instance, err error) {
-	svc, err := d.createSVC(secret, providerSpec.Region)
-	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
-	}
-	instances, err = getMachineInstancesByTagsAndStatus(svc, machine.Name, providerSpec.Tags)
+func (d *Driver) getMatchingInstancesForMachine(machine *v1alpha1.Machine, svc ec2iface.EC2API, providerSpecTags map[string]string) (instances []*ec2.Instance, err error) {
+	instances, err = getMachineInstancesByTagsAndStatus(svc, machine.Name, providerSpecTags)
 	if err != nil {
 		return nil, err
 	}
@@ -198,7 +194,7 @@ func confirmInstanceByID(svc ec2iface.EC2API, instanceID string) (bool, error) {
 func (d *Driver) generateBlockDevices(blockDevices []api.AWSBlockDeviceMappingSpec, rootDeviceName *string) ([]*ec2.BlockDeviceMapping, error) {
 	// If not blockDevices are passed, return an error.
 	if len(blockDevices) == 0 {
-		return nil, fmt.Errorf("No block devices passed")
+		return nil, fmt.Errorf("no block devices passed")
 	}
 
 	var blkDeviceMappings []*ec2.BlockDeviceMapping

--- a/pkg/aws/core_util_test.go
+++ b/pkg/aws/core_util_test.go
@@ -237,7 +237,7 @@ var _ = Describe("CoreUtils", func() {
 
 			Expect(disksGenerated).To(Equal(expectedDisks))
 			Expect(err).To(HaveOccurred())
-			Expect(err).To(Equal(fmt.Errorf("No block devices passed")))
+			Expect(err).To(Equal(fmt.Errorf("no block devices passed")))
 		})
 
 		It("should not encrypt blockDevices by default", func() {

--- a/pkg/aws/errors/utils.go
+++ b/pkg/aws/errors/utils.go
@@ -30,3 +30,9 @@ func GetMCMErrorCodeForTerminateInstances(err error) codes.Code {
 		return codes.Internal
 	}
 }
+
+// IsInstanceIDNotFound checks if the provider returned an InstanceIDNotFound error
+func IsInstanceIDNotFound(err error) bool {
+	awsErr := err.(awserr.Error)
+	return awsErr.Code() == InstanceIDNotFound
+}

--- a/pkg/aws/util.go
+++ b/pkg/aws/util.go
@@ -12,6 +12,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/codes"
+	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/status"
+
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	backoff "github.com/cenkalti/backoff/v4"
 	corev1 "k8s.io/api/core/v1"
@@ -43,6 +46,15 @@ func (d *Driver) createSVC(secret *corev1.Secret, region string) (ec2iface.EC2AP
 	}
 	svc := d.SPI.NewEC2API(session)
 	return svc, nil
+}
+
+// Function returns true only if error code equals codes.NotFound
+func isNotFoundError(err error) bool {
+	errorStatus, ok := status.FromError(err)
+	if ok && errorStatus.Code() == codes.NotFound {
+		return true
+	}
+	return false
 }
 
 // kubernetesVolumeIDToEBSVolumeID translates Kubernetes volume ID to EBS volume ID

--- a/pkg/aws/util.go
+++ b/pkg/aws/util.go
@@ -32,7 +32,7 @@ func encodeInstanceID(region, instanceID string) string {
 func decodeRegionAndInstanceID(id string) (string, string, error) {
 	splitProviderID := strings.Split(id, "/")
 	if len(splitProviderID) < 2 {
-		err := fmt.Errorf("Unable to decode provider-ID")
+		err := fmt.Errorf("unable to decode provider-ID")
 		return "", "", err
 	}
 	return splitProviderID[len(splitProviderID)-2], splitProviderID[len(splitProviderID)-1], nil


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces a fallback for fetching the VM instances associated with a machine. 

It also changes `InitializeMachine` to return error code `Uninitialized`, instead of `NotFound` when instances cannot be found for the machine.

**Which issue(s) this PR fixes**:
Fixes part of https://github.com/gardener/machine-controller-manager/issues/933

**Special notes for your reviewer**:

The changes were manually tested by doing the following:

1. Returning an error from `getInstancesByTagsOrInstanceID()`, such that `instanceID` is fetched by the fallback `getInstanceByID()`. Found that Machine was created successfully and went into Running state.
2. returning `codes.NotFound` from `getMatchingInstancesForMachine()`. On triggering machine creation, initialization was tried in a loop after `shortRetry`.


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
3. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Use `ProviderID` as a fallback for fetching the VM.
```

```other operator
`InitializeMachine` returns `Uninitialized` error code if VM is not found.
```
