### PR TITLE
Set PrimaryIpv6 flag for instances with IPv6 addresses.

### DIFF
--- a/pkg/aws/core.go
+++ b/pkg/aws/core.go
@@ -147,6 +147,7 @@ func (d *Driver) CreateMachine(_ context.Context, req *driver.CreateMachineReque
 
 		if netIf.Ipv6AddressCount != nil {
 			spec.Ipv6AddressCount = netIf.Ipv6AddressCount
+			spec.PrimaryIpv6 = aws.Bool(true)
 		}
 
 		networkInterfaceSpecs = append(networkInterfaceSpecs, spec)


### PR DESCRIPTION
This is needed to add an instance with an IPv6 address as target to a loadbalancer.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Set PrimaryIpv6 flag for instances with IPv6 addresses.
```
