### PR TITLE
[GEP-26] Add support for workload identity

### DIFF
--- a/pkg/aws/apis/validation/validation.go
+++ b/pkg/aws/apis/validation/validation.go
@@ -25,16 +25,16 @@ func ValidateAWSProviderSpec(spec *awsapi.AWSProviderSpec, secret *corev1.Secret
 		allErrs = field.ErrorList{}
 	)
 
-	if "" == spec.AMI {
+	if spec.AMI == "" {
 		allErrs = append(allErrs, field.Required(fldPath.Child("ami"), "AMI is required"))
 	}
-	if "" == spec.Region {
+	if spec.Region == "" {
 		allErrs = append(allErrs, field.Required(fldPath.Child("region"), "Region is required"))
 	}
-	if "" == spec.MachineType {
+	if spec.MachineType == "" {
 		allErrs = append(allErrs, field.Required(fldPath.Child("machineType"), "MachineType is required"))
 	}
-	if ("" == spec.IAM.Name && "" == spec.IAM.ARN) || ("" != spec.IAM.Name && "" != spec.IAM.ARN) {
+	if (spec.IAM.Name == "" && spec.IAM.ARN == "") || (spec.IAM.Name != "" && spec.IAM.ARN != "") {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("iam"), spec.IAM, "either IAM Name or ARN must be set"))
 	}
 
@@ -156,15 +156,15 @@ func validateNetworkInterfaces(networkInterfaces []awsapi.AWSNetworkInterfaceSpe
 		allErrs = append(allErrs, field.Required(fldPath.Child(""), "Mention at least one NetworkInterface"))
 	} else {
 		for i := range networkInterfaces {
-			if "" == networkInterfaces[i].SubnetID {
+			if networkInterfaces[i].SubnetID == "" {
 				allErrs = append(allErrs, field.Required(fldPath.Child("subnetID"), "SubnetID is required"))
 			}
 
-			if 0 == len(networkInterfaces[i].SecurityGroupIDs) {
+			if len(networkInterfaces[i].SecurityGroupIDs) == 0 {
 				allErrs = append(allErrs, field.Required(fldPath.Child("securityGroupIDs"), "Mention at least one securityGroupID"))
 			} else {
 				for j := range networkInterfaces[i].SecurityGroupIDs {
-					if "" == networkInterfaces[i].SecurityGroupIDs[j] {
+					if networkInterfaces[i].SecurityGroupIDs[j] == "" {
 						output := strings.Join([]string{"securityGroupIDs cannot be blank for networkInterface:", strconv.Itoa(i), " securityGroupID:", strconv.Itoa(j)}, "")
 						allErrs = append(allErrs, field.Required(fldPath.Child("securityGroupIDs"), output))
 					}

--- a/pkg/aws/apis/validation/validation.go
+++ b/pkg/aws/apis/validation/validation.go
@@ -238,6 +238,9 @@ func ValidateSecret(secret *corev1.Secret, fldPath *field.Path) field.ErrorList 
 		if roleARN, ok := secret.Data["roleARN"]; !ok || len(roleARN) == 0 {
 			allErrs = append(allErrs, field.Required(fldPath.Child("roleARN"), "Role ARN is required when workload identity is used"))
 		}
+		if string(secret.Data["userData"]) == "" {
+			allErrs = append(allErrs, field.Required(fldPath.Child("userData"), "Mention userData"))
+		}
 	} else {
 		if string(secret.Data[awsapi.AWSAccessKeyID]) == "" && string(secret.Data[awsapi.AWSAlternativeAccessKeyID]) == "" {
 			allErrs = append(allErrs, field.Required(fldPath.Child("AWSAccessKeyID"), fmt.Sprintf("Mention atleast %s or %s", awsapi.AWSAccessKeyID, awsapi.AWSAlternativeAccessKeyID)))

--- a/pkg/aws/apis/validation/validation.go
+++ b/pkg/aws/apis/validation/validation.go
@@ -19,11 +19,6 @@ import (
 	awsapi "github.com/gardener/machine-controller-manager-provider-aws/pkg/aws/apis"
 )
 
-const nameFmt string = `[-a-z0-9]+`
-const nameMaxLength int = 63
-
-var nameRegexp = regexp.MustCompile("^" + nameFmt + "$")
-
 // ValidateAWSProviderSpec validates AWS provider spec
 func ValidateAWSProviderSpec(spec *awsapi.AWSProviderSpec, secret *corev1.Secret, fldPath *field.Path) field.ErrorList {
 	var (

--- a/pkg/aws/apis/validation/validation.go
+++ b/pkg/aws/apis/validation/validation.go
@@ -230,14 +230,22 @@ func ValidateSecret(secret *corev1.Secret, fldPath *field.Path) field.ErrorList 
 
 	if secret == nil {
 		allErrs = append(allErrs, field.Required(fldPath.Child(""), "secretRef is required"))
+	} else if workloadIdentityTokenFile, ok := secret.Data["workloadIdentityTokenFile"]; ok {
+		if len(workloadIdentityTokenFile) == 0 {
+			allErrs = append(allErrs, field.Required(fldPath.Child("workloadIdentityTokenFile"), "Workload identity token file is required"))
+		}
+
+		if roleARN, ok := secret.Data["roleARN"]; !ok || len(roleARN) == 0 {
+			allErrs = append(allErrs, field.Required(fldPath.Child("roleARN"), "Role ARN is required when workload identity is used"))
+		}
 	} else {
-		if "" == string(secret.Data[awsapi.AWSAccessKeyID]) && "" == string(secret.Data[awsapi.AWSAlternativeAccessKeyID]) {
+		if string(secret.Data[awsapi.AWSAccessKeyID]) == "" && string(secret.Data[awsapi.AWSAlternativeAccessKeyID]) == "" {
 			allErrs = append(allErrs, field.Required(fldPath.Child("AWSAccessKeyID"), fmt.Sprintf("Mention atleast %s or %s", awsapi.AWSAccessKeyID, awsapi.AWSAlternativeAccessKeyID)))
 		}
-		if "" == string(secret.Data[awsapi.AWSSecretAccessKey]) && "" == string(secret.Data[awsapi.AWSAlternativeSecretAccessKey]) {
+		if string(secret.Data[awsapi.AWSSecretAccessKey]) == "" && string(secret.Data[awsapi.AWSAlternativeSecretAccessKey]) == "" {
 			allErrs = append(allErrs, field.Required(fldPath.Child("AWSSecretAccessKey"), fmt.Sprintf("Mention atleast %s or %s", awsapi.AWSSecretAccessKey, awsapi.AWSAlternativeSecretAccessKey)))
 		}
-		if "" == string(secret.Data["userData"]) {
+		if string(secret.Data["userData"]) == "" {
 			allErrs = append(allErrs, field.Required(fldPath.Child("userData"), "Mention userData"))
 		}
 	}

--- a/pkg/aws/apis/validation/validation_test.go
+++ b/pkg/aws/apis/validation/validation_test.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/onsi/gomega/gstruct"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	awsapi "github.com/gardener/machine-controller-manager-provider-aws/pkg/aws/apis"
 )
@@ -78,7 +78,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     pointer.String("test-ssh-publickey"),
+						KeyName:     ptr.To("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -117,7 +117,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     pointer.String("test-ssh-publickey"),
+						KeyName:     ptr.To("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -157,7 +157,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     pointer.String("test-ssh-publickey"),
+						KeyName:     ptr.To("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -194,7 +194,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     pointer.String("test-ssh-publickey"),
+						KeyName:     ptr.To("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -239,7 +239,7 @@ var _ = Describe("Validation", func() {
 							Name: "test-iam",
 						},
 						MachineType: "m4.large",
-						KeyName:     pointer.String("test-ssh-publickey"),
+						KeyName:     ptr.To("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -284,7 +284,7 @@ var _ = Describe("Validation", func() {
 							Name: "test-iam",
 						},
 						Region:  "eu-west-1",
-						KeyName: pointer.String("test-ssh-publickey"),
+						KeyName: ptr.To("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -328,7 +328,7 @@ var _ = Describe("Validation", func() {
 						IAM:         awsapi.AWSIAMProfileSpec{},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     pointer.String("test-ssh-publickey"),
+						KeyName:     ptr.To("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -375,7 +375,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     pointer.String("test-ssh-publickey"),
+						KeyName:     ptr.To("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -424,7 +424,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     pointer.String("test-ssh-publickey"),
+						KeyName:     ptr.To("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -469,7 +469,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     pointer.String("test-ssh-publickey"),
+						KeyName:     ptr.To("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -522,7 +522,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     pointer.String("test-ssh-publickey"),
+						KeyName:     ptr.To("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -568,7 +568,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     pointer.String("test-ssh-publickey"),
+						KeyName:     ptr.To("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -629,7 +629,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     pointer.String("test-ssh-publickey"),
+						KeyName:     ptr.To("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -675,7 +675,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     pointer.String("test-ssh-publickey"),
+						KeyName:     ptr.To("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -720,7 +720,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     pointer.String("test-ssh-publickey"),
+						KeyName:     ptr.To("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -766,7 +766,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     pointer.String("test-ssh-publickey"),
+						KeyName:     ptr.To("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -812,7 +812,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     pointer.String("test-ssh-publickey"),
+						KeyName:     ptr.To("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -858,7 +858,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     pointer.String("test-ssh-publickey"),
+						KeyName:     ptr.To("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -897,7 +897,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     pointer.String("test-ssh-publickey"),
+						KeyName:     ptr.To("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -945,7 +945,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     pointer.String("test-ssh-publickey"),
+						KeyName:     ptr.To("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -991,7 +991,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     pointer.String("test-ssh-publickey"),
+						KeyName:     ptr.To("test-ssh-publickey"),
 						Tags: map[string]string{
 							"kubernetes.io/cluster/shoot--test": "1",
 							"kubernetes.io/role/test":           "1",
@@ -1029,7 +1029,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     pointer.String("test-ssh-publickey"),
+						KeyName:     ptr.To("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -1074,7 +1074,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     pointer.String("test-ssh-publickey"),
+						KeyName:     ptr.To("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SubnetID: "subnet-123456",
@@ -1117,7 +1117,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     pointer.String("test-ssh-publickey"),
+						KeyName:     ptr.To("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -1168,7 +1168,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     pointer.String("test-ssh-publickey"),
+						KeyName:     ptr.To("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -1219,7 +1219,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     pointer.String("test-ssh-publickey"),
+						KeyName:     ptr.To("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -1263,7 +1263,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     pointer.String("test-ssh-publickey"),
+						KeyName:     ptr.To("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -1314,7 +1314,7 @@ var _ = Describe("Validation", func() {
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     pointer.String("test-ssh-publickey"),
+						KeyName:     ptr.To("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -1346,7 +1346,7 @@ var _ = Describe("Validation", func() {
 				setup: setup{
 					apply: func(spec *awsapi.AWSProviderSpec) {
 						spec.InstanceMetadataOptions = &awsapi.InstanceMetadataOptions{
-							HTTPPutResponseHopLimit: pointer.Int64(32),
+							HTTPPutResponseHopLimit: ptr.To[int64](32),
 						}
 					},
 				},
@@ -1362,7 +1362,7 @@ var _ = Describe("Validation", func() {
 				setup: setup{
 					apply: func(spec *awsapi.AWSProviderSpec) {
 						spec.InstanceMetadataOptions = &awsapi.InstanceMetadataOptions{
-							HTTPPutResponseHopLimit: pointer.Int64(72),
+							HTTPPutResponseHopLimit: ptr.To[int64](72),
 						}
 					},
 				},
@@ -1386,7 +1386,7 @@ var _ = Describe("Validation", func() {
 				setup: setup{
 					apply: func(spec *awsapi.AWSProviderSpec) {
 						spec.InstanceMetadataOptions = &awsapi.InstanceMetadataOptions{
-							HTTPEndpoint: pointer.String(awsapi.HTTPEndpointDisabled),
+							HTTPEndpoint: ptr.To(awsapi.HTTPEndpointDisabled),
 						}
 					},
 				},
@@ -1402,7 +1402,7 @@ var _ = Describe("Validation", func() {
 				setup: setup{
 					apply: func(spec *awsapi.AWSProviderSpec) {
 						spec.InstanceMetadataOptions = &awsapi.InstanceMetadataOptions{
-							HTTPEndpoint: pointer.String("foobar"),
+							HTTPEndpoint: ptr.To("foobar"),
 						}
 					},
 				},
@@ -1426,7 +1426,7 @@ var _ = Describe("Validation", func() {
 				setup: setup{
 					apply: func(spec *awsapi.AWSProviderSpec) {
 						spec.InstanceMetadataOptions = &awsapi.InstanceMetadataOptions{
-							HTTPTokens: pointer.String(awsapi.HTTPTokensRequired),
+							HTTPTokens: ptr.To(awsapi.HTTPTokensRequired),
 						}
 					},
 				},
@@ -1442,7 +1442,7 @@ var _ = Describe("Validation", func() {
 				setup: setup{
 					apply: func(spec *awsapi.AWSProviderSpec) {
 						spec.InstanceMetadataOptions = &awsapi.InstanceMetadataOptions{
-							HTTPTokens: pointer.String("foobar"),
+							HTTPTokens: ptr.To("foobar"),
 						}
 					},
 				},
@@ -1476,16 +1476,16 @@ var _ = Describe("Validation", func() {
 							},
 						},
 						CapacityReservationTarget: &awsapi.AWSCapacityReservationTargetSpec{
-							CapacityReservationPreference:       pointer.String("open"),
-							CapacityReservationID:               pointer.String("capacity-reservation-id-abcd1234"),
-							CapacityReservationResourceGroupArn: pointer.String("arn:01234:/my-resource-group"),
+							CapacityReservationPreference:       ptr.To("open"),
+							CapacityReservationID:               ptr.To("capacity-reservation-id-abcd1234"),
+							CapacityReservationResourceGroupArn: ptr.To("arn:01234:/my-resource-group"),
 						},
 						IAM: awsapi.AWSIAMProfileSpec{
 							Name: "test-iam",
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     pointer.String("test-ssh-publickey"),
+						KeyName:     ptr.To("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -1533,15 +1533,15 @@ var _ = Describe("Validation", func() {
 							},
 						},
 						CapacityReservationTarget: &awsapi.AWSCapacityReservationTargetSpec{
-							CapacityReservationPreference: pointer.String("open"),
-							CapacityReservationID:         pointer.String("capacity-reservation-id-abcd1234"),
+							CapacityReservationPreference: ptr.To("open"),
+							CapacityReservationID:         ptr.To("capacity-reservation-id-abcd1234"),
 						},
 						IAM: awsapi.AWSIAMProfileSpec{
 							Name: "test-iam",
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     pointer.String("test-ssh-publickey"),
+						KeyName:     ptr.To("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -1589,15 +1589,15 @@ var _ = Describe("Validation", func() {
 							},
 						},
 						CapacityReservationTarget: &awsapi.AWSCapacityReservationTargetSpec{
-							CapacityReservationPreference:       pointer.String("open"),
-							CapacityReservationResourceGroupArn: pointer.String("arn:01234:/my-resource-group"),
+							CapacityReservationPreference:       ptr.To("open"),
+							CapacityReservationResourceGroupArn: ptr.To("arn:01234:/my-resource-group"),
 						},
 						IAM: awsapi.AWSIAMProfileSpec{
 							Name: "test-iam",
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     pointer.String("test-ssh-publickey"),
+						KeyName:     ptr.To("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -1645,15 +1645,15 @@ var _ = Describe("Validation", func() {
 							},
 						},
 						CapacityReservationTarget: &awsapi.AWSCapacityReservationTargetSpec{
-							CapacityReservationID:               pointer.String("capacity-reservation-id-abcd1234"),
-							CapacityReservationResourceGroupArn: pointer.String("arn:01234:/my-resource-group"),
+							CapacityReservationID:               ptr.To("capacity-reservation-id-abcd1234"),
+							CapacityReservationResourceGroupArn: ptr.To("arn:01234:/my-resource-group"),
 						},
 						IAM: awsapi.AWSIAMProfileSpec{
 							Name: "test-iam",
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     pointer.String("test-ssh-publickey"),
+						KeyName:     ptr.To("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -1701,14 +1701,14 @@ var _ = Describe("Validation", func() {
 							},
 						},
 						CapacityReservationTarget: &awsapi.AWSCapacityReservationTargetSpec{
-							CapacityReservationID: pointer.String("capacity-reservation-id-abcd1234"),
+							CapacityReservationID: ptr.To("capacity-reservation-id-abcd1234"),
 						},
 						IAM: awsapi.AWSIAMProfileSpec{
 							Name: "test-iam",
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     pointer.String("test-ssh-publickey"),
+						KeyName:     ptr.To("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -1748,14 +1748,14 @@ var _ = Describe("Validation", func() {
 							},
 						},
 						CapacityReservationTarget: &awsapi.AWSCapacityReservationTargetSpec{
-							CapacityReservationResourceGroupArn: pointer.String("arn:01234:/my-resource-group"),
+							CapacityReservationResourceGroupArn: ptr.To("arn:01234:/my-resource-group"),
 						},
 						IAM: awsapi.AWSIAMProfileSpec{
 							Name: "test-iam",
 						},
 						Region:      "eu-west-1",
 						MachineType: "m4.large",
-						KeyName:     pointer.String("test-ssh-publickey"),
+						KeyName:     ptr.To("test-ssh-publickey"),
 						NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 							{
 								SecurityGroupIDs: []string{
@@ -1841,14 +1841,14 @@ func validAWSProviderSpec() *awsapi.AWSProviderSpec {
 			},
 		},
 		CapacityReservationTarget: &awsapi.AWSCapacityReservationTargetSpec{
-			CapacityReservationPreference: pointer.String("open"),
+			CapacityReservationPreference: ptr.To("open"),
 		},
 		IAM: awsapi.AWSIAMProfileSpec{
 			Name: "test-iam",
 		},
 		Region:      "eu-west-1",
 		MachineType: "m4.large",
-		KeyName:     pointer.String("test-ssh-publickey"),
+		KeyName:     ptr.To("test-ssh-publickey"),
 		NetworkInterfaces: []awsapi.AWSNetworkInterfaceSpec{
 			{
 				SecurityGroupIDs: []string{

--- a/pkg/spi/aws.go
+++ b/pkg/spi/aws.go
@@ -28,16 +28,16 @@ func (ms *PluginSPIImpl) NewSession(secret *corev1.Secret, region string) (*sess
 		Region: aws.String(region),
 	}
 
-	if arn, ok := secret.Data["roleARN"]; ok {
+	if workloadIdentityTokenFile, ok := secret.Data["workloadIdentityTokenFile"]; ok {
 		sess, err := session.NewSession()
 		if err != nil {
 			return nil, err
 		}
 		webIDProvider := stscreds.NewWebIdentityRoleProviderWithOptions(
 			sts.New(sess),
-			string(arn),
+			string(secret.Data["roleARN"]),
 			secret.Namespace,
-			stscreds.FetchTokenPath(secret.Data["workloadIdentityTokenFile"]),
+			stscreds.FetchTokenPath(workloadIdentityTokenFile),
 		)
 		creds, err := webIDProvider.Retrieve()
 		if err != nil {

--- a/pkg/spi/aws.go
+++ b/pkg/spi/aws.go
@@ -9,9 +9,11 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/aws/aws-sdk-go/service/sts"
 	corev1 "k8s.io/api/core/v1"
 
 	api "github.com/gardener/machine-controller-manager-provider-aws/pkg/aws/apis"
@@ -24,6 +26,29 @@ type PluginSPIImpl struct{}
 func (ms *PluginSPIImpl) NewSession(secret *corev1.Secret, region string) (*session.Session, error) {
 	var config = &aws.Config{
 		Region: aws.String(region),
+	}
+
+	if arn, ok := secret.Data["roleARN"]; ok {
+		sess, err := session.NewSession()
+		if err != nil {
+			return nil, err
+		}
+		webIDProvider := stscreds.NewWebIdentityRoleProviderWithOptions(
+			sts.New(sess),
+			string(arn),
+			secret.Namespace,
+			stscreds.FetchTokenPath(secret.Data["workloadIdentityTokenFile"]),
+		)
+		creds, err := webIDProvider.Retrieve()
+		if err != nil {
+			return nil, err
+		}
+		cc := credentials.NewStaticCredentialsFromCreds(creds)
+		config := &aws.Config{
+			Region:      aws.String(region),
+			Credentials: cc,
+		}
+		return session.NewSession(config)
 	}
 
 	accessKeyID := extractCredentialsFromData(secret.Data, api.AWSAccessKeyID, api.AWSAlternativeAccessKeyID)

--- a/pkg/spi/aws.go
+++ b/pkg/spi/aws.go
@@ -44,10 +44,7 @@ func (ms *PluginSPIImpl) NewSession(secret *corev1.Secret, region string) (*sess
 			return nil, err
 		}
 		cc := credentials.NewStaticCredentialsFromCreds(creds)
-		config := &aws.Config{
-			Region:      aws.String(region),
-			Credentials: cc,
-		}
+		config.Credentials = cc
 		return session.NewSession(config)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a new way of authentication against AWS based on workload (web) identity token and a role that is going to be assumed.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/9586

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
MCM now supports workload identity authentication. This can be configured if the secret contains `roleARN` and `workloadIdentityTokenFile`.
```
