### PR TITLE
Add a `nil` check to `(*Driver).GetMachineStatus` to avoid a `panic`.

### DIFF
--- a/pkg/aws/core.go
+++ b/pkg/aws/core.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/codes"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/status"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 
 	awserror "github.com/gardener/machine-controller-manager-provider-aws/pkg/aws/errors"
 	"github.com/gardener/machine-controller-manager-provider-aws/pkg/spi"
@@ -441,7 +442,7 @@ func (d *Driver) GetMachineStatus(_ context.Context, req *driver.GetMachineStatu
 
 	// if SrcAnDstCheckEnabled is false then check attribute on instance and return Uninitialized error if not matching.
 	if providerSpec.SrcAndDstChecksEnabled != nil && !*providerSpec.SrcAndDstChecksEnabled {
-		if *requiredInstance.SourceDestCheck {
+		if ptr.Deref(requiredInstance.SourceDestCheck, false) {
 			msg := fmt.Sprintf("VM %q associated with machine %q has SourceDestCheck=%t despite providerSpec.SrcAndDstChecksEnabled=%t",
 				*requiredInstance.InstanceId, req.Machine.Name, *requiredInstance.SourceDestCheck, *providerSpec.SrcAndDstChecksEnabled)
 			klog.Warning(msg)

--- a/pkg/aws/core_util.go
+++ b/pkg/aws/core_util.go
@@ -22,7 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -67,7 +67,7 @@ func disableSrcAndDestCheck(svc ec2iface.EC2API, instanceID *string) error {
 	srcAndDstCheckEnabled := &ec2.ModifyInstanceAttributeInput{
 		InstanceId: instanceID,
 		SourceDestCheck: &ec2.AttributeBooleanValue{
-			Value: pointer.BoolPtr(false),
+			Value: ptr.To(false),
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

- Adds a `nil` check to `(*Driver).GetMachineStatus` to avoid a `panic`, observed like so:

```
I1201 05:07:55.734060       1 machine.go:81] Adding machine object to queue "x/y" after 5s, reason: Machine deletion in process. Phase set to termination
I1201 05:07:55.789335       1 panic.go:770] reconcileClusterMachine: Stop for "z"
E1201 05:07:55.789441       1 panic.go:261] "Observed a panic" panic="runtime error: invalid memory address or nil pointer dereference" panicGoValue="\"invalid memory address or nil pointer dereference\"" stacktrace=<
    goroutine 372 [running]:
    k8s.io/apimachinery/pkg/util/runtime.logPanic({0x2d637b8, 0x4300640}, {0x21f4a20, 0x4266c70})
        /go/pkg/mod/k8s.io/apimachinery@v0.31.0/pkg/util/runtime/runtime.go:107 +0xbc
    k8s.io/apimachinery/pkg/util/runtime.handleCrash({0x2d637b8, 0x4300640}, {0x21f4a20, 0x4266c70}, {0x4300640, 0x0, 0x10000c0046550c0?})
        /go/pkg/mod/k8s.io/apimachinery@v0.31.0/pkg/util/runtime/runtime.go:82 +0x5e
    k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0xc0046550c0?})
        /go/pkg/mod/k8s.io/apimachinery@v0.31.0/pkg/util/runtime/runtime.go:59 +0x108
    panic({0x21f4a20?, 0x4266c70?})
        /usr/local/go/src/runtime/panic.go:770 +0x132
    github.com/gardener/machine-controller-manager-provider-aws/pkg/aws.(*Driver).GetMachineStatus(0xc000117030, {0xc0025d4708?, 0xc006edd540?}, 0xc004fd0270)
        /go/src/github.com/gardener/machine-controller-manager-provider-aws/pkg/aws/core.go:444 +0x64d
    github.com/gardener/machine-controller-manager/pkg/util/provider/machinecontroller.(*controller).triggerCreationFlow(0xc0006f0288, {0x2d637b8, 0x4300640}, 0xc0012a6660)
        /go/pkg/mod/github.com/gardener/machine-controller-manager@v0.54.0/pkg/util/provider/machinecontroller/machine.go:372 +0x1e6
    github.com/gardener/machine-controller-manager/pkg/util/provider/machinecontroller.(*controller).reconcileClusterMachine(0xc0006f0288, {0x2d637b8, 0x4300640}, 0xc0025d4708)
        /go/pkg/mod/github.com/gardener/machine-controller-manager@v0.54.0/pkg/util/provider/machinecontroller/machine.go:183 +0xba5
    github.com/gardener/machine-controller-manager/pkg/util/provider/machinecontroller.(*controller).reconcileClusterMachineKey(0xc0006f0288, {0xc001911180, 0x4d})
        /go/pkg/mod/github.com/gardener/machine-controller-manager@v0.54.0/pkg/util/provider/machinecontroller/machine.go:104 +0x1f0
    github.com/gardener/machine-controller-manager/pkg/util/worker.Run.func1.worker.1.1({0x7fa1e2e93750, 0xc0005b6300}, 0xc000f8c660, 0x1, 0xf, {0x26501c6, 0xe})
        /go/pkg/mod/github.com/gardener/machine-controller-manager@v0.54.0/pkg/util/worker/worker.go:48 +0x110
    github.com/gardener/machine-controller-manager/pkg/util/worker.Run.func1.worker.1()
        /go/pkg/mod/github.com/gardener/machine-controller-manager@v0.54.0/pkg/util/worker/worker.go:65 +0x56
    k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x30?)
        /go/pkg/mod/k8s.io/apimachinery@v0.31.0/pkg/util/wait/backoff.go:226 +0x33
    k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc004bf9f90, {0x2d3d100, 0xc00468e030}, 0x1, 0x0)
        /go/pkg/mod/k8s.io/apimachinery@v0.31.0/pkg/util/wait/backoff.go:227 +0xaf
    k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc002285f90, 0x3b9aca00, 0x0, 0x1, 0x0)
        /go/pkg/mod/k8s.io/apimachinery@v0.31.0/pkg/util/wait/backoff.go:204 +0x7f
    k8s.io/apimachinery/pkg/util/wait.Until(...)
        /go/pkg/mod/k8s.io/apimachinery@v0.31.0/pkg/util/wait/backoff.go:161
    github.com/gardener/machine-controller-manager/pkg/util/worker.Run.func1()
        /go/pkg/mod/github.com/gardener/machine-controller-manager@v0.54.0/pkg/util/worker/worker.go:27 +0x9b
    created by github.com/gardener/machine-controller-manager/pkg/util/worker.Run in goroutine 164
        /go/pkg/mod/github.com/gardener/machine-controller-manager@v0.54.0/pkg/util/worker/worker.go:26 +0xf3
 >
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
    panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x119c7ad]
```

- Replace the deprecated `pointer.BoolPtr` calls with `ptr.To` calls.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix a panic that occurs while fetching the status of a VM backing a machine from the provider.
```
