### PR TITLE
Fix: install ginkgo if not available during integration tests

### DIFF
--- a/.ci/local_integration_test
+++ b/.ci/local_integration_test
@@ -105,7 +105,7 @@ fi
 if ! hash ginkgo; then
     # Install Ginkgo (test framework) to be able to execute the tests.
     echo "Fetching Ginkgo frawework"
-    GO111MODULE=off go get -u github.com/onsi/ginkgo/ginkgo
+    GO111MODULE=on go install github.com/onsi/ginkgo/v2/ginkgo
     echo "Successfully fetched Ginkgo frawework"
 fi
 

--- a/.ci/pipeline_integration_test
+++ b/.ci/pipeline_integration_test
@@ -36,7 +36,7 @@ export MACHINE_CONTROLLER_MANAGER_DEPLOYMENT_NAME="machine-controller-manager"
 
 function setup_ginkgo() {
     echo "Installing Ginkgo..."
-    GO111MODULE=off go get -u github.com/onsi/ginkgo/ginkgo
+    GO111MODULE=on go install github.com/onsi/ginkgo/v2/ginkgo
     ginkgo version
     echo "Successfully installed Ginkgo."
 }


### PR DESCRIPTION
Currently if ginkgo is not found on the system while running
the integration tests, it just fetches it and doesn't install
the required package, so calls to `go get` were replaced with
`go install` for the proper ginkgo version (v2) which
has support for the flags used while running the tests.

-------

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```