### PR TITLE
Added `verify` make target

### DIFF
--- a/.ci/verify
+++ b/.ci/verify
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+cd "$(dirname $0)/.."
+
+git config --global user.email "gardener@sap.com"
+git config --global user.name "Gardener CI/CD"
+
+make verify

--- a/Makefile
+++ b/Makefile
@@ -76,10 +76,14 @@ update-dependencies:
 .PHONY: test-unit
 test-unit:
 	@SKIP_INTEGRATION_TESTS=X .ci/test
-	
+
 .PHONY: test-integration
 test-integration:
 	.ci/local_integration_test
+
+.PHONY: test
+test:
+	.ci/test
 
 #########################################
 # Rules for build/release
@@ -132,3 +136,6 @@ sast: $(GOSEC)
 .PHONY: sast-report
 sast-report: $(GOSEC)
 	@./hack/sast.sh --gosec-report true
+
+.PHONY: verify
+verify: check build test


### PR DESCRIPTION
-------

**What this PR does / why we need it**:
Consolidation of multiple `make` targets to simplify pipeline definitions

**Which issue(s) this PR fixes**:
Part of gardener/machine-controller-manager#930

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```