### PR TITLE
Fix nil pointer exception for SrcDestCheck and update the default value

### DIFF
--- a/pkg/aws/core.go
+++ b/pkg/aws/core.go
@@ -279,7 +279,7 @@ func (d *Driver) InitializeMachine(_ context.Context, request *driver.Initialize
 	targetInstance := instances[0]
 	providerID := encodeInstanceID(providerSpec.Region, *targetInstance.InstanceId)
 	// if SrcAnDstCheckEnabled is false then disable the SrcAndDestCheck on running NAT instance
-	if providerSpec.SrcAndDstChecksEnabled != nil && !*providerSpec.SrcAndDstChecksEnabled && *targetInstance.SourceDestCheck {
+	if providerSpec.SrcAndDstChecksEnabled != nil && !*providerSpec.SrcAndDstChecksEnabled && ptr.Deref(targetInstance.SourceDestCheck, true) {
 		klog.V(3).Infof("Disabling SourceDestCheck on VM %q associated with machine %s", providerID, request.Machine.Name)
 		err = disableSrcAndDestCheck(svc, targetInstance.InstanceId)
 		if err != nil {
@@ -445,7 +445,7 @@ func (d *Driver) GetMachineStatus(_ context.Context, req *driver.GetMachineStatu
 
 	// if SrcAnDstCheckEnabled is false then check attribute on instance and return Uninitialized error if not matching.
 	if providerSpec.SrcAndDstChecksEnabled != nil && !*providerSpec.SrcAndDstChecksEnabled {
-		if ptr.Deref(requiredInstance.SourceDestCheck, false) {
+		if ptr.Deref(requiredInstance.SourceDestCheck, true) {
 			msg := fmt.Sprintf("VM %q associated with machine %q has SourceDestCheck=%t despite providerSpec.SrcAndDstChecksEnabled=%t",
 				*requiredInstance.InstanceId, req.Machine.Name, *requiredInstance.SourceDestCheck, *providerSpec.SrcAndDstChecksEnabled)
 			klog.Warning(msg)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR does the following 
1. Fix a potential nil pointer exception wrt `targetInstance.SourceDestCheck`
2. Update the default value when trying to dereference `targetInstance.SourceDestCheck`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
3. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
