### PR TITLE
Set region when creating session

### DIFF
--- a/pkg/spi/aws.go
+++ b/pkg/spi/aws.go
@@ -29,7 +29,7 @@ func (ms *PluginSPIImpl) NewSession(secret *corev1.Secret, region string) (*sess
 	}
 
 	if workloadIdentityTokenFile, ok := secret.Data["workloadIdentityTokenFile"]; ok {
-		sess, err := session.NewSession()
+		sess, err := session.NewSession(aws.NewConfig().WithRegion(region))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
If the region is not set the retrieval of credentials might fail with the following error:

```
WebIdentityErr: failed to retrieve credentials
caused by: InvalidIdentityToken: No OpenIDConnect provider found in your account for https://issuer.example
        status code: 400, request id: <id-of-request>
```


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A bug causing failure in retrieval of credentials when using workload identity due to missing region parameter was fixed.
```
