### PR TITLE
Adjust required permissions for `upgrade-dependencies.yaml` workflow

### DIFF
--- a/.github/workflows/upgrade-dependencies.yaml
+++ b/.github/workflows/upgrade-dependencies.yaml
@@ -10,6 +10,6 @@ jobs:
     secrets: inherit
     permissions:
       contents: write
-      pull-requests: write
+      id-token: write
     with:
       prepare-action-path: ./.github/actions/setup-go


### PR DESCRIPTION
The `pull-request: write` permission is (and was) actually not required for this workflow. Instead, `id-token: write` will be required in the future because of a (yet) missing OIDC usage within the workflow.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
