### PR TITLE
Add support for enabling instance IPv6 IMDS

### DIFF
--- a/kubernetes/machine-class.yaml
+++ b/kubernetes/machine-class.yaml
@@ -47,8 +47,9 @@ providerSpec:
     tag2: tag2-value # A set of additional tags attached to a machine (optional)
   instanceMetadataOptions: # Optional - configures access to instance metadata service for VMs.
     httpEndpoint: "enabled" # Optional - enable or disable access to IMDS.
+    httpPutResponseHopLimit: 1 # Optional - When set to >=2 access to IMDSv2 is enabled from inside virtualized environments like the containers inside a kubernetes cluster.
     httpTokens: "optional" # Optional - when set to "required" only access to IMDSv2 is allowed.
-    HTTPPutResponseHopLimit: 1 # Optional - When set to >=2 access to IMDSv2 is enabled from inside virtualized environments like the containers inside a kubernetes cluster.
+    httpProtocolIpv6: "enabled" # Optional - When set to "enabled" IMDS is accessible over IPv6.
 secretRef: # Secret pointing to a secret which contains the provider secret and cloudconfig
   namespace: default  # Namespace
   name: test-secret # Name of the secret

--- a/kubernetes/machine-class.yaml
+++ b/kubernetes/machine-class.yaml
@@ -49,7 +49,7 @@ providerSpec:
     httpEndpoint: "enabled" # Optional - enable or disable access to IMDS.
     httpPutResponseHopLimit: 1 # Optional - When set to >=2 access to IMDSv2 is enabled from inside virtualized environments like the containers inside a kubernetes cluster.
     httpTokens: "optional" # Optional - when set to "required" only access to IMDSv2 is allowed.
-    httpProtocolIpv6: "enabled" # Optional - When set to "enabled" IMDS is accessible over IPv6.
+    httpProtocolIpv6: "disabled" # Optional - When set to "enabled" IMDS is accessible over IPv6.
 secretRef: # Secret pointing to a secret which contains the provider secret and cloudconfig
   namespace: default  # Namespace
   name: test-secret # Name of the secret

--- a/pkg/aws/apis/aws_provider_spec.go
+++ b/pkg/aws/apis/aws_provider_spec.go
@@ -250,6 +250,13 @@ type AWSNetworkInterfaceSpec struct {
 }
 
 const (
+	// HTTPProtocolIPv6Enabled enforces enabling the IPv6 endpoint for the instance metadata service.
+	HTTPProtocolIPv6Enabled string = "enabled"
+	// HTTPProtocolIPv6Disabled enforces disabling the IPv6 endpoint for the instance metadata service.
+	HTTPProtocolIPv6Disabled string = "disabled"
+)
+
+const (
 	// HTTPTokensRequired enforces the use of tokens to access the metadata service. Effectively it enforces IMDSv2.
 	HTTPTokensRequired string = "required"
 	// HTTPTokensOptional allows the use of both IMDSv1 and IMDSv2.
@@ -272,6 +279,8 @@ type InstanceMetadataOptions struct {
 	HTTPPutResponseHopLimit *int32 `json:"httpPutResponseHopLimit,omitempty"`
 	// HTTPTokens enforces the use of metadata v2 API.
 	HTTPTokens string `json:"httpTokens,omitempty"`
+	// HTTPProtocolIPv6 enables or disables the IPv6 endpoint for the instance metadata service.
+	HTTPProtocolIPv6 string `json:"httpProtocolIpv6,omitempty"`
 }
 
 // CPUOptions contains detailed configuration for the number of cores and threads for the instance.

--- a/pkg/aws/apis/aws_provider_spec.go
+++ b/pkg/aws/apis/aws_provider_spec.go
@@ -250,13 +250,6 @@ type AWSNetworkInterfaceSpec struct {
 }
 
 const (
-	// HTTPProtocolIPv6Enabled enforces enabling the IPv6 endpoint for the instance metadata service.
-	HTTPProtocolIPv6Enabled string = "enabled"
-	// HTTPProtocolIPv6Disabled enforces disabling the IPv6 endpoint for the instance metadata service.
-	HTTPProtocolIPv6Disabled string = "disabled"
-)
-
-const (
 	// HTTPTokensRequired enforces the use of tokens to access the metadata service. Effectively it enforces IMDSv2.
 	HTTPTokensRequired string = "required"
 	// HTTPTokensOptional allows the use of both IMDSv1 and IMDSv2.

--- a/pkg/aws/apis/validation/validation.go
+++ b/pkg/aws/apis/validation/validation.go
@@ -194,6 +194,10 @@ func validateInstanceMetadata(metadata *awsapi.InstanceMetadataOptions, fldPath 
 		allErrs = append(allErrs, validateStringValues(fldPath.Child("httpTokens"), metadata.HTTPTokens, []string{awsapi.HTTPTokensRequired, awsapi.HTTPTokensOptional})...)
 	}
 
+	if metadata.HTTPProtocolIPv6 != "" {
+		allErrs = append(allErrs, validateStringValues(fldPath.Child("httpProtocolIpv6"), metadata.HTTPProtocolIPv6, []string{awsapi.HTTPProtocolIPv6Enabled, awsapi.HTTPProtocolIPv6Disabled})...)
+	}
+
 	return allErrs
 }
 

--- a/pkg/aws/apis/validation/validation.go
+++ b/pkg/aws/apis/validation/validation.go
@@ -195,7 +195,11 @@ func validateInstanceMetadata(metadata *awsapi.InstanceMetadataOptions, fldPath 
 	}
 
 	if metadata.HTTPProtocolIPv6 != "" {
-		allErrs = append(allErrs, validateStringValues(fldPath.Child("httpProtocolIpv6"), metadata.HTTPProtocolIPv6, []string{awsapi.HTTPProtocolIPv6Enabled, awsapi.HTTPProtocolIPv6Disabled})...)
+		allErrs = append(allErrs, validateStringValues(fldPath.Child("httpProtocolIpv6"), metadata.HTTPProtocolIPv6,
+			[]string{
+				string(ec2types.InstanceMetadataProtocolStateEnabled),
+				string(ec2types.InstanceMetadataProtocolStateDisabled),
+			})...)
 	}
 
 	return allErrs

--- a/pkg/aws/apis/validation/validation_test.go
+++ b/pkg/aws/apis/validation/validation_test.go
@@ -1463,6 +1463,47 @@ var _ = Describe("Validation", func() {
 					},
 				},
 			}),
+			Entry("AWS machine class with instanceMetadata with valid instanceMetadata.httpProtocolIpv6", &data{
+				setup: setup{
+					apply: func(spec *awsapi.AWSProviderSpec) {
+						spec.InstanceMetadataOptions = &awsapi.InstanceMetadataOptions{
+							HTTPProtocolIPv6: awsapi.HTTPProtocolIPv6Enabled,
+						}
+					},
+				},
+				action: action{
+					spec:   validAWSProviderSpec(),
+					secret: providerSecret,
+				},
+				expect: expect{
+					errToHaveOccurred: false,
+				},
+			}),
+			Entry("AWS machine class with invalid instanceMetadata.httpProtocolIpv6", &data{
+				setup: setup{
+					apply: func(spec *awsapi.AWSProviderSpec) {
+						spec.InstanceMetadataOptions = &awsapi.InstanceMetadataOptions{
+							HTTPProtocolIPv6: "foobar",
+						}
+					},
+				},
+				action: action{
+					spec:   validAWSProviderSpec(),
+					secret: providerSecret,
+				},
+				expect: expect{
+					errToHaveOccurred: true,
+					errList: field.ErrorList{
+						{
+							Type:     "FieldValueInvalid",
+							Field:    "providerSpec.instanceMetadata.httpProtocolIpv6",
+							BadValue: "foobar",
+							Detail: fmt.Sprintf("Accepted values: [%s %s]",
+								awsapi.HTTPProtocolIPv6Enabled, awsapi.HTTPProtocolIPv6Disabled),
+						},
+					},
+				},
+			}),
 			Entry("CapacityReservationTargetSpec invalid spec configuring both preference, target id and arn", &data{
 				setup: setup{},
 				action: action{

--- a/pkg/aws/apis/validation/validation_test.go
+++ b/pkg/aws/apis/validation/validation_test.go
@@ -1467,7 +1467,7 @@ var _ = Describe("Validation", func() {
 				setup: setup{
 					apply: func(spec *awsapi.AWSProviderSpec) {
 						spec.InstanceMetadataOptions = &awsapi.InstanceMetadataOptions{
-							HTTPProtocolIPv6: awsapi.HTTPProtocolIPv6Enabled,
+							HTTPProtocolIPv6: string(ec2types.InstanceMetadataProtocolStateEnabled),
 						}
 					},
 				},
@@ -1499,7 +1499,8 @@ var _ = Describe("Validation", func() {
 							Field:    "providerSpec.instanceMetadata.httpProtocolIpv6",
 							BadValue: "foobar",
 							Detail: fmt.Sprintf("Accepted values: [%s %s]",
-								awsapi.HTTPProtocolIPv6Enabled, awsapi.HTTPProtocolIPv6Disabled),
+								string(ec2types.InstanceMetadataProtocolStateEnabled),
+								string(ec2types.InstanceMetadataProtocolStateDisabled)),
 						},
 					},
 				},

--- a/pkg/aws/core.go
+++ b/pkg/aws/core.go
@@ -82,7 +82,7 @@ func (d *Driver) CreateMachine(ctx context.Context, req *driver.CreateMachineReq
 	}
 
 	// Log messages to track request
-	klog.V(3).Infof("Machine creation request has been recieved for %q", req.Machine.Name)
+	klog.V(3).Infof("Machine creation request has been received for %q", req.Machine.Name)
 
 	providerSpec, err := decodeProviderSpecAndSecret(machineClass, secret)
 	if err != nil {
@@ -97,7 +97,7 @@ func (d *Driver) CreateMachine(ctx context.Context, req *driver.CreateMachineReq
 	if userData, exists = secret.Data["userData"]; !exists {
 		return nil, status.Error(codes.Internal, "userData doesn't exist")
 	}
-	UserDataEnc := base64.StdEncoding.EncodeToString([]byte(userData))
+	UserDataEnc := base64.StdEncoding.EncodeToString(userData)
 
 	var imageIds []string
 	imageID := providerSpec.AMI
@@ -171,6 +171,7 @@ func (d *Driver) CreateMachine(ctx context.Context, req *driver.CreateMachineReq
 			HttpEndpoint:            ec2types.InstanceMetadataEndpointState(providerSpec.InstanceMetadataOptions.HTTPEndpoint),
 			HttpPutResponseHopLimit: providerSpec.InstanceMetadataOptions.HTTPPutResponseHopLimit,
 			HttpTokens:              ec2types.HttpTokensState(providerSpec.InstanceMetadataOptions.HTTPTokens),
+			HttpProtocolIpv6:        ec2types.InstanceMetadataProtocolState(providerSpec.InstanceMetadataOptions.HTTPProtocolIPv6),
 		}
 	}
 

--- a/pkg/aws/errors/codes.go
+++ b/pkg/aws/errors/codes.go
@@ -59,5 +59,4 @@ const (
 	// Unsupported is returned when the specified request is unsupported. For example, you might be trying to launch an instance in an
 	// Availability Zone that currently has constraints on that instance type. The returned message provides details of the unsupported request.
 	Unsupported = "Unsupported"
-	
 )


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
This PR adds support for enabling instance IPv6 IMDS.
Per default this option is disabled.

**Which issue(s) this PR fixes**:
Needed for https://github.com/gardener/gardener-extension-provider-aws/issues/1640

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add support for enabling instance IPv6 IMDS
```
