### PR TITLE
Add EFA network interface, placement, and ML capacity block support

### DIFF
--- a/pkg/aws/apis/aws_provider_spec.go
+++ b/pkg/aws/apis/aws_provider_spec.go
@@ -100,6 +100,9 @@ type AWSProviderSpec struct {
 
 	// CPUOptions contains detailed configuration for the number of cores and threads for the instance.
 	CPUOptions *CPUOptions `json:"cpuOptions,omitempty"`
+
+	// Placement contains placement configuration for the instance (placement groups, tenancy, dedicated hosts).
+	Placement *AWSPlacementSpec `json:"placement,omitempty"`
 }
 
 // AWSBlockDeviceMappingSpec stores info about AWS block device mappings
@@ -140,6 +143,10 @@ type AWSCapacityReservationTargetSpec struct {
 
 	// CapacityReservationResourceGroupArn The ARN of the Capacity Reservation in which to run the instance.
 	CapacityReservationResourceGroupArn *string `json:"capacityReservationResourceGroupArn,omitempty"`
+
+	// IsMLCapacityBlock indicates this reservation is an ML capacity block.
+	// Sets InstanceMarketOptions.MarketType to "capacity-block".
+	IsMLCapacityBlock *bool `json:"isMLCapacityBlock,omitempty"`
 }
 
 // AWSEbsBlockDeviceSpec describes a block device for an EBS volume.
@@ -247,6 +254,33 @@ type AWSNetworkInterfaceSpec struct {
 	// The ID of the subnet associated with the network string. Applies only if
 	// creating a network interface when launching an machine.
 	SubnetID string `json:"subnetID,omitempty"`
+
+	// InterfaceType is the type of network interface.
+	// Valid values: "interface" (default), "efa", "efa-only".
+	InterfaceType string `json:"interfaceType,omitempty"`
+
+	// NetworkCardIndex is the index of the network card for this interface.
+	NetworkCardIndex *int32 `json:"networkCardIndex,omitempty"`
+
+	// DeviceIndex is the device index for this network interface.
+	DeviceIndex *int32 `json:"deviceIndex,omitempty"`
+
+	// PrimaryIpv6 indicates whether the first IPv6 address is the primary IPv6 address.
+	PrimaryIpv6 *bool `json:"primaryIpv6,omitempty"`
+}
+
+// AWSPlacementSpec contains placement configuration for an EC2 instance.
+type AWSPlacementSpec struct {
+	// GroupID is the ID of the placement group.
+	GroupID *string `json:"groupId,omitempty"`
+	// Tenancy is the tenancy of the instance. Valid values: "default", "dedicated", "host".
+	Tenancy *string `json:"tenancy,omitempty"`
+	// HostID is the ID of the Dedicated Host.
+	HostID *string `json:"hostId,omitempty"`
+	// PartitionNumber is the partition number for the instance.
+	PartitionNumber *int64 `json:"partitionNumber,omitempty"`
+	// Affinity is the affinity setting. Valid values: "default", "host".
+	Affinity *string `json:"affinity,omitempty"`
 }
 
 const (

--- a/pkg/aws/apis/aws_provider_spec.go
+++ b/pkg/aws/apis/aws_provider_spec.go
@@ -85,8 +85,9 @@ type AWSProviderSpec struct {
 	// Region contains the AWS region for the machine
 	Region string `json:"region,omitempty"`
 
-	// SpotPrice is an optional field that if set specifies to use spot instances
-	// When set to "" there is no maxPrice else, specifies the maxPrice
+	// SpotPrice is an optional field that if set specifies to use spot instances.
+	// When set to "" there is no maxPrice, else specifies the maxPrice.
+	// Deprecated: Use InstanceMarketOptions with MarketType "spot" instead.
 	SpotPrice *string `json:"spotPrice,omitempty"`
 
 	// If set to false, source and destination checks are disabled, default is true
@@ -103,6 +104,10 @@ type AWSProviderSpec struct {
 
 	// Placement contains placement configuration for the instance (placement groups, tenancy, dedicated hosts).
 	Placement *AWSPlacementSpec `json:"placement,omitempty"`
+
+	// InstanceMarketOptions configures the instance market type.
+	// If not specified, on-demand instances are launched.
+	InstanceMarketOptions *AWSInstanceMarketOptions `json:"instanceMarketOptions,omitempty"`
 }
 
 // AWSBlockDeviceMappingSpec stores info about AWS block device mappings
@@ -143,10 +148,13 @@ type AWSCapacityReservationTargetSpec struct {
 
 	// CapacityReservationResourceGroupArn The ARN of the Capacity Reservation in which to run the instance.
 	CapacityReservationResourceGroupArn *string `json:"capacityReservationResourceGroupArn,omitempty"`
+}
 
-	// IsMLCapacityBlock indicates this reservation is an ML capacity block.
-	// Sets InstanceMarketOptions.MarketType to "capacity-block".
-	IsMLCapacityBlock *bool `json:"isMLCapacityBlock,omitempty"`
+// AWSInstanceMarketOptions configures the instance market type.
+type AWSInstanceMarketOptions struct {
+	// MarketType is the market type for the instance.
+	// Supported values: "spot", "capacity-block", "interruptible-capacity-reservation".
+	MarketType string `json:"marketType"`
 }
 
 // AWSEbsBlockDeviceSpec describes a block device for an EBS volume.

--- a/pkg/aws/apis/aws_provider_spec.go
+++ b/pkg/aws/apis/aws_provider_spec.go
@@ -280,7 +280,7 @@ type AWSPlacementSpec struct {
 	// HostID is the ID of the Dedicated Host.
 	HostID *string `json:"hostId,omitempty"`
 	// PartitionNumber is the partition number for the instance.
-	PartitionNumber *int64 `json:"partitionNumber,omitempty"`
+	PartitionNumber *int32 `json:"partitionNumber,omitempty"`
 	// Affinity is the affinity setting. Valid values: "default", "host".
 	Affinity *string `json:"affinity,omitempty"`
 }

--- a/pkg/aws/apis/aws_provider_spec.go
+++ b/pkg/aws/apis/aws_provider_spec.go
@@ -256,8 +256,10 @@ type AWSNetworkInterfaceSpec struct {
 	SubnetID string `json:"subnetID,omitempty"`
 
 	// InterfaceType is the type of network interface.
-	// Valid values: "interface" (default), "efa", "efa-only".
-	InterfaceType string `json:"interfaceType,omitempty"`
+	// Currently valid values for RunInstances: "interface", "efa", "efa-only".
+	// See https://github.com/aws/aws-sdk-go-v2/blob/service/ec2/v1.279.0/service/ec2/types/types.go#L9181
+	// If not specified, defaults to "interface".
+	InterfaceType *string `json:"interfaceType,omitempty"`
 
 	// NetworkCardIndex is the index of the network card for this interface.
 	NetworkCardIndex *int32 `json:"networkCardIndex,omitempty"`

--- a/pkg/aws/apis/validation/validation.go
+++ b/pkg/aws/apis/validation/validation.go
@@ -42,6 +42,7 @@ func ValidateAWSProviderSpec(spec *awsapi.AWSProviderSpec, secret *corev1.Secret
 	allErrs = append(allErrs, validateBlockDevices(spec.BlockDevices, fldPath.Child("blockDevices"))...)
 	allErrs = append(allErrs, validateCapacityReservations(spec.CapacityReservationTarget, fldPath.Child("capacityReservation"))...)
 	allErrs = append(allErrs, validateNetworkInterfaces(spec.NetworkInterfaces, fldPath.Child("networkInterfaces"))...)
+	allErrs = append(allErrs, validatePlacement(spec.Placement, fldPath.Child("placement"))...)
 	allErrs = append(allErrs, ValidateSecret(secret, field.NewPath("secretRef"))...)
 	allErrs = append(allErrs, validateSpecTags(spec.Tags, fldPath.Child("tags"))...)
 	allErrs = append(allErrs, validateInstanceMetadata(spec.InstanceMetadataOptions, fldPath.Child("instanceMetadata"))...)
@@ -143,9 +144,20 @@ func validateCapacityReservations(capacityReservation *awsapi.AWSCapacityReserva
 		} else if capacityReservation.CapacityReservationID != nil && capacityReservation.CapacityReservationResourceGroupArn != nil {
 			allErrs = append(allErrs, field.Required(fldPath, "CapacityReservationResourceGroupArn or CapacityReservationId are optional but only one should be used"))
 		}
+
+		if capacityReservation.IsMLCapacityBlock != nil && *capacityReservation.IsMLCapacityBlock && capacityReservation.CapacityReservationID == nil {
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child("isMLCapacityBlock"), "isMLCapacityBlock can only be set when capacityReservationId is specified"))
+		}
 	}
 
 	return allErrs
+}
+
+var validNetworkInterfaceTypes = []string{
+	"",
+	string(ec2types.NetworkInterfaceTypeInterface),
+	string(ec2types.NetworkInterfaceTypeEfa),
+	string(ec2types.NetworkInterfaceTypeEfaOnly),
 }
 
 func validateNetworkInterfaces(networkInterfaces []awsapi.AWSNetworkInterfaceSpec, fldPath *field.Path) field.ErrorList {
@@ -157,19 +169,33 @@ func validateNetworkInterfaces(networkInterfaces []awsapi.AWSNetworkInterfaceSpe
 		allErrs = append(allErrs, field.Required(fldPath.Child(""), "Mention at least one NetworkInterface"))
 	} else {
 		for i := range networkInterfaces {
+			idxPath := fldPath.Index(i)
+
 			if networkInterfaces[i].SubnetID == "" {
-				allErrs = append(allErrs, field.Required(fldPath.Child("subnetID"), "SubnetID is required"))
+				allErrs = append(allErrs, field.Required(idxPath.Child("subnetID"), "SubnetID is required"))
 			}
 
 			if len(networkInterfaces[i].SecurityGroupIDs) == 0 {
-				allErrs = append(allErrs, field.Required(fldPath.Child("securityGroupIDs"), "Mention at least one securityGroupID"))
+				allErrs = append(allErrs, field.Required(idxPath.Child("securityGroupIDs"), "Mention at least one securityGroupID"))
 			} else {
 				for j := range networkInterfaces[i].SecurityGroupIDs {
 					if networkInterfaces[i].SecurityGroupIDs[j] == "" {
 						output := strings.Join([]string{"securityGroupIDs cannot be blank for networkInterface:", strconv.Itoa(i), " securityGroupID:", strconv.Itoa(j)}, "")
-						allErrs = append(allErrs, field.Required(fldPath.Child("securityGroupIDs"), output))
+						allErrs = append(allErrs, field.Required(idxPath.Child("securityGroupIDs"), output))
 					}
 				}
+			}
+
+			if networkInterfaces[i].InterfaceType != "" && !slices.Contains(validNetworkInterfaceTypes, networkInterfaces[i].InterfaceType) {
+				allErrs = append(allErrs, field.NotSupported(idxPath.Child("interfaceType"), networkInterfaces[i].InterfaceType, validNetworkInterfaceTypes[1:]))
+			}
+
+			if networkInterfaces[i].DeviceIndex != nil && *networkInterfaces[i].DeviceIndex < 0 {
+				allErrs = append(allErrs, field.Invalid(idxPath.Child("deviceIndex"), *networkInterfaces[i].DeviceIndex, "must be >= 0"))
+			}
+
+			if networkInterfaces[i].NetworkCardIndex != nil && *networkInterfaces[i].NetworkCardIndex < 0 {
+				allErrs = append(allErrs, field.Invalid(idxPath.Child("networkCardIndex"), *networkInterfaces[i].NetworkCardIndex, "must be >= 0"))
 			}
 		}
 	}
@@ -286,4 +312,35 @@ func validateStringValues(fld *field.Path, s string, accepted []string) field.Er
 	}
 
 	return field.ErrorList{field.Invalid(fld, s, fmt.Sprintf("Accepted values: %v", accepted))}
+}
+
+func validatePlacement(placement *awsapi.AWSPlacementSpec, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if placement == nil {
+		return allErrs
+	}
+
+	if placement.Tenancy != nil {
+		validTenancies := []string{"default", "dedicated", "host"}
+		if !slices.Contains(validTenancies, *placement.Tenancy) {
+			allErrs = append(allErrs, field.NotSupported(fldPath.Child("tenancy"), *placement.Tenancy, validTenancies))
+		}
+	}
+
+	if placement.Affinity != nil {
+		validAffinities := []string{"default", "host"}
+		if !slices.Contains(validAffinities, *placement.Affinity) {
+			allErrs = append(allErrs, field.NotSupported(fldPath.Child("affinity"), *placement.Affinity, validAffinities))
+		}
+	}
+
+	if placement.HostID != nil && (placement.Tenancy == nil || *placement.Tenancy != "host") {
+		allErrs = append(allErrs, field.Forbidden(fldPath.Child("hostId"), "hostId can only be set when tenancy is \"host\""))
+	}
+
+	if placement.PartitionNumber != nil && *placement.PartitionNumber < 1 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("partitionNumber"), *placement.PartitionNumber, "must be >= 1"))
+	}
+
+	return allErrs
 }

--- a/pkg/aws/apis/validation/validation.go
+++ b/pkg/aws/apis/validation/validation.go
@@ -186,8 +186,8 @@ func validateNetworkInterfaces(networkInterfaces []awsapi.AWSNetworkInterfaceSpe
 				}
 			}
 
-			if networkInterfaces[i].InterfaceType != "" && !slices.Contains(validNetworkInterfaceTypes, networkInterfaces[i].InterfaceType) {
-				allErrs = append(allErrs, field.NotSupported(idxPath.Child("interfaceType"), networkInterfaces[i].InterfaceType, validNetworkInterfaceTypes[1:]))
+			if networkInterfaces[i].InterfaceType != nil && !slices.Contains(validNetworkInterfaceTypes, *networkInterfaces[i].InterfaceType) {
+				allErrs = append(allErrs, field.NotSupported(idxPath.Child("interfaceType"), *networkInterfaces[i].InterfaceType, validNetworkInterfaceTypes[1:]))
 			}
 
 			if networkInterfaces[i].DeviceIndex != nil && *networkInterfaces[i].DeviceIndex < 0 {

--- a/pkg/aws/apis/validation/validation.go
+++ b/pkg/aws/apis/validation/validation.go
@@ -43,6 +43,7 @@ func ValidateAWSProviderSpec(spec *awsapi.AWSProviderSpec, secret *corev1.Secret
 	allErrs = append(allErrs, validateCapacityReservations(spec.CapacityReservationTarget, fldPath.Child("capacityReservation"))...)
 	allErrs = append(allErrs, validateNetworkInterfaces(spec.NetworkInterfaces, fldPath.Child("networkInterfaces"))...)
 	allErrs = append(allErrs, validatePlacement(spec.Placement, fldPath.Child("placement"))...)
+	allErrs = append(allErrs, validateInstanceMarketOptions(spec.InstanceMarketOptions, fldPath.Child("instanceMarketOptions"))...)
 	allErrs = append(allErrs, ValidateSecret(secret, field.NewPath("secretRef"))...)
 	allErrs = append(allErrs, validateSpecTags(spec.Tags, fldPath.Child("tags"))...)
 	allErrs = append(allErrs, validateInstanceMetadata(spec.InstanceMetadataOptions, fldPath.Child("instanceMetadata"))...)
@@ -143,10 +144,6 @@ func validateCapacityReservations(capacityReservation *awsapi.AWSCapacityReserva
 			}
 		} else if capacityReservation.CapacityReservationID != nil && capacityReservation.CapacityReservationResourceGroupArn != nil {
 			allErrs = append(allErrs, field.Required(fldPath, "CapacityReservationResourceGroupArn or CapacityReservationId are optional but only one should be used"))
-		}
-
-		if capacityReservation.IsMLCapacityBlock != nil && *capacityReservation.IsMLCapacityBlock && capacityReservation.CapacityReservationID == nil {
-			allErrs = append(allErrs, field.Forbidden(fldPath.Child("isMLCapacityBlock"), "isMLCapacityBlock can only be set when capacityReservationId is specified"))
 		}
 	}
 
@@ -340,6 +337,25 @@ func validatePlacement(placement *awsapi.AWSPlacementSpec, fldPath *field.Path) 
 
 	if placement.PartitionNumber != nil && *placement.PartitionNumber < 1 {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("partitionNumber"), *placement.PartitionNumber, "must be >= 1"))
+	}
+
+	return allErrs
+}
+
+func validateInstanceMarketOptions(opts *awsapi.AWSInstanceMarketOptions, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if opts == nil {
+		return allErrs
+	}
+
+	validMarketTypes := ec2types.MarketType("").Values()
+	validStrings := make([]string, len(validMarketTypes))
+	for i, v := range validMarketTypes {
+		validStrings[i] = string(v)
+	}
+
+	if !slices.Contains(validStrings, opts.MarketType) {
+		allErrs = append(allErrs, field.NotSupported(fldPath.Child("marketType"), opts.MarketType, validStrings))
 	}
 
 	return allErrs

--- a/pkg/aws/apis/validation/validation_test.go
+++ b/pkg/aws/apis/validation/validation_test.go
@@ -1050,7 +1050,7 @@ var _ = Describe("Validation", func() {
 					errList: field.ErrorList{
 						{
 							Type:     "FieldValueRequired",
-							Field:    "providerSpec.networkInterfaces.subnetID",
+							Field:    "providerSpec.networkInterfaces[0].subnetID",
 							BadValue: "",
 							Detail:   "SubnetID is required",
 						},
@@ -1093,7 +1093,7 @@ var _ = Describe("Validation", func() {
 					errList: field.ErrorList{
 						{
 							Type:     "FieldValueRequired",
-							Field:    "providerSpec.networkInterfaces.securityGroupIDs",
+							Field:    "providerSpec.networkInterfaces[0].securityGroupIDs",
 							BadValue: "",
 							Detail:   "Mention at least one securityGroupID",
 						},
@@ -1336,7 +1336,7 @@ var _ = Describe("Validation", func() {
 					errList: field.ErrorList{
 						{
 							Type:     "FieldValueRequired",
-							Field:    "providerSpec.networkInterfaces.securityGroupIDs",
+							Field:    "providerSpec.networkInterfaces[0].securityGroupIDs",
 							BadValue: "",
 							Detail:   "securityGroupIDs cannot be blank for networkInterface:0 securityGroupID:0",
 						},
@@ -1822,6 +1822,144 @@ var _ = Describe("Validation", func() {
 				},
 				expect: expect{
 					errToHaveOccurred: false,
+				},
+			}),
+			Entry("Invalid interfaceType for network interface", &data{
+				setup: setup{
+					apply: func(spec *awsapi.AWSProviderSpec) {
+						spec.NetworkInterfaces[0].InterfaceType = "invalid"
+					},
+				},
+				action: action{
+					spec:   validAWSProviderSpec(),
+					secret: providerSecret,
+				},
+				expect: expect{
+					errToHaveOccurred: true,
+					errList: field.ErrorList{
+						{
+							Type:     "FieldValueNotSupported",
+							Field:    "providerSpec.networkInterfaces[0].interfaceType",
+							BadValue: "invalid",
+							Detail:   `supported values: "interface", "efa", "efa-only"`,
+						},
+					},
+				},
+			}),
+			Entry("Negative deviceIndex for network interface", &data{
+				setup: setup{
+					apply: func(spec *awsapi.AWSProviderSpec) {
+						spec.NetworkInterfaces[0].DeviceIndex = ptr.To[int32](-1)
+					},
+				},
+				action: action{
+					spec:   validAWSProviderSpec(),
+					secret: providerSecret,
+				},
+				expect: expect{
+					errToHaveOccurred: true,
+					errList: field.ErrorList{
+						{
+							Type:     "FieldValueInvalid",
+							Field:    "providerSpec.networkInterfaces[0].deviceIndex",
+							BadValue: int32(-1),
+							Detail:   "must be >= 0",
+						},
+					},
+				},
+			}),
+			Entry("Negative networkCardIndex for network interface", &data{
+				setup: setup{
+					apply: func(spec *awsapi.AWSProviderSpec) {
+						spec.NetworkInterfaces[0].NetworkCardIndex = ptr.To[int32](-1)
+					},
+				},
+				action: action{
+					spec:   validAWSProviderSpec(),
+					secret: providerSecret,
+				},
+				expect: expect{
+					errToHaveOccurred: true,
+					errList: field.ErrorList{
+						{
+							Type:     "FieldValueInvalid",
+							Field:    "providerSpec.networkInterfaces[0].networkCardIndex",
+							BadValue: int32(-1),
+							Detail:   "must be >= 0",
+						},
+					},
+				},
+			}),
+			Entry("isMLCapacityBlock without capacityReservationId", &data{
+				setup: setup{
+					apply: func(spec *awsapi.AWSProviderSpec) {
+						spec.CapacityReservationTarget = &awsapi.AWSCapacityReservationTargetSpec{
+							IsMLCapacityBlock: ptr.To(true),
+						}
+					},
+				},
+				action: action{
+					spec:   validAWSProviderSpec(),
+					secret: providerSecret,
+				},
+				expect: expect{
+					errToHaveOccurred: true,
+					errList: field.ErrorList{
+						{
+							Type:     "FieldValueForbidden",
+							Field:    "providerSpec.capacityReservation.isMLCapacityBlock",
+							BadValue: "",
+							Detail:   "isMLCapacityBlock can only be set when capacityReservationId is specified",
+						},
+					},
+				},
+			}),
+			Entry("Invalid placement tenancy", &data{
+				setup: setup{
+					apply: func(spec *awsapi.AWSProviderSpec) {
+						spec.Placement = &awsapi.AWSPlacementSpec{
+							Tenancy: ptr.To("invalid"),
+						}
+					},
+				},
+				action: action{
+					spec:   validAWSProviderSpec(),
+					secret: providerSecret,
+				},
+				expect: expect{
+					errToHaveOccurred: true,
+					errList: field.ErrorList{
+						{
+							Type:     "FieldValueNotSupported",
+							Field:    "providerSpec.placement.tenancy",
+							BadValue: "invalid",
+							Detail:   `supported values: "default", "dedicated", "host"`,
+						},
+					},
+				},
+			}),
+			Entry("Placement hostId without tenancy host", &data{
+				setup: setup{
+					apply: func(spec *awsapi.AWSProviderSpec) {
+						spec.Placement = &awsapi.AWSPlacementSpec{
+							HostID: ptr.To("h-12345"),
+						}
+					},
+				},
+				action: action{
+					spec:   validAWSProviderSpec(),
+					secret: providerSecret,
+				},
+				expect: expect{
+					errToHaveOccurred: true,
+					errList: field.ErrorList{
+						{
+							Type:     "FieldValueForbidden",
+							Field:    "providerSpec.placement.hostId",
+							BadValue: "",
+							Detail:   `hostId can only be set when tenancy is "host"`,
+						},
+					},
 				},
 			}),
 		)

--- a/pkg/aws/apis/validation/validation_test.go
+++ b/pkg/aws/apis/validation/validation_test.go
@@ -1890,11 +1890,11 @@ var _ = Describe("Validation", func() {
 					},
 				},
 			}),
-			Entry("isMLCapacityBlock without capacityReservationId", &data{
+			Entry("Invalid instanceMarketOptions marketType", &data{
 				setup: setup{
 					apply: func(spec *awsapi.AWSProviderSpec) {
-						spec.CapacityReservationTarget = &awsapi.AWSCapacityReservationTargetSpec{
-							IsMLCapacityBlock: ptr.To(true),
+						spec.InstanceMarketOptions = &awsapi.AWSInstanceMarketOptions{
+							MarketType: "invalid",
 						}
 					},
 				},
@@ -1906,10 +1906,10 @@ var _ = Describe("Validation", func() {
 					errToHaveOccurred: true,
 					errList: field.ErrorList{
 						{
-							Type:     "FieldValueForbidden",
-							Field:    "providerSpec.capacityReservation.isMLCapacityBlock",
-							BadValue: "",
-							Detail:   "isMLCapacityBlock can only be set when capacityReservationId is specified",
+							Type:     "FieldValueNotSupported",
+							Field:    "providerSpec.instanceMarketOptions.marketType",
+							BadValue: "invalid",
+							Detail:   `supported values: "spot", "capacity-block", "interruptible-capacity-reservation"`,
 						},
 					},
 				},

--- a/pkg/aws/apis/validation/validation_test.go
+++ b/pkg/aws/apis/validation/validation_test.go
@@ -1827,7 +1827,7 @@ var _ = Describe("Validation", func() {
 			Entry("Invalid interfaceType for network interface", &data{
 				setup: setup{
 					apply: func(spec *awsapi.AWSProviderSpec) {
-						spec.NetworkInterfaces[0].InterfaceType = "invalid"
+						spec.NetworkInterfaces[0].InterfaceType = ptr.To("invalid")
 					},
 				},
 				action: action{

--- a/pkg/aws/core.go
+++ b/pkg/aws/core.go
@@ -138,11 +138,24 @@ func (d *Driver) CreateMachine(ctx context.Context, req *driver.CreateMachineReq
 	for i, netIf := range providerSpec.NetworkInterfaces {
 		spec := ec2types.InstanceNetworkInterfaceSpecification{
 			Groups:                   netIf.SecurityGroupIDs,
-			DeviceIndex:              aws.Int32(int32(i)), // #nosec: G115 -- index will not exceed int32 limits
 			AssociatePublicIpAddress: netIf.AssociatePublicIPAddress,
 			DeleteOnTermination:      netIf.DeleteOnTermination,
 			Description:              netIf.Description,
 			SubnetId:                 aws.String(netIf.SubnetID),
+		}
+
+		if netIf.DeviceIndex != nil {
+			spec.DeviceIndex = netIf.DeviceIndex
+		} else {
+			spec.DeviceIndex = aws.Int32(int32(i)) // #nosec: G115 -- index will not exceed int32 limits
+		}
+
+		if netIf.NetworkCardIndex != nil {
+			spec.NetworkCardIndex = netIf.NetworkCardIndex
+		}
+
+		if netIf.InterfaceType != "" {
+			spec.InterfaceType = ptr.To(netIf.InterfaceType)
 		}
 
 		if netIf.DeleteOnTermination == nil {
@@ -151,7 +164,11 @@ func (d *Driver) CreateMachine(ctx context.Context, req *driver.CreateMachineReq
 
 		if netIf.Ipv6AddressCount != nil {
 			spec.Ipv6AddressCount = netIf.Ipv6AddressCount
-			spec.PrimaryIpv6 = aws.Bool(true)
+			if netIf.PrimaryIpv6 != nil {
+				spec.PrimaryIpv6 = netIf.PrimaryIpv6
+			} else {
+				spec.PrimaryIpv6 = aws.Bool(true)
+			}
 		}
 
 		networkInterfaceSpecs = append(networkInterfaceSpecs, spec)
@@ -214,14 +231,41 @@ func (d *Driver) CreateMachine(ctx context.Context, req *driver.CreateMachineReq
 				CapacityReservationResourceGroupArn: providerSpec.CapacityReservationTarget.CapacityReservationResourceGroupArn,
 			},
 		}
+		if ptr.Deref(providerSpec.CapacityReservationTarget.IsMLCapacityBlock, false) {
+			inputConfig.InstanceMarketOptions = &ec2types.InstanceMarketOptionsRequest{
+				MarketType: ec2types.MarketTypeCapacityBlock,
+			}
+		}
 	}
 
-	placement, err := getPlacementObj(req)
-	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
-	} else if placement != nil {
+	// Set placement from providerSpec (first-class API), falling back to annotation
+	if providerSpec.Placement != nil {
+		placement := &ec2types.Placement{}
+		if providerSpec.Placement.GroupID != nil {
+			placement.GroupId = providerSpec.Placement.GroupID
+		}
+		if providerSpec.Placement.Tenancy != nil {
+			placement.Tenancy = ec2types.Tenancy(*providerSpec.Placement.Tenancy)
+		}
+		if providerSpec.Placement.HostID != nil {
+			placement.HostId = providerSpec.Placement.HostID
+		}
+		if providerSpec.Placement.PartitionNumber != nil {
+			placement.PartitionNumber = aws.Int32(int32(*providerSpec.Placement.PartitionNumber)) // #nosec: G115 -- partition number will not exceed int32 limits
+		}
+		if providerSpec.Placement.Affinity != nil {
+			placement.Affinity = providerSpec.Placement.Affinity
+		}
 		inputConfig.Placement = placement
+	} else {
+		placement, err := getPlacementObj(req)
+		if err != nil {
+			return nil, status.Error(codes.Internal, err.Error())
+		} else if placement != nil {
+			inputConfig.Placement = placement
+		}
 	}
+
 	// Set spot price if it has been set
 	if providerSpec.SpotPrice != nil {
 		inputConfig.InstanceMarketOptions = &ec2types.InstanceMarketOptionsRequest{
@@ -496,10 +540,22 @@ func (d *Driver) GetMachineStatus(ctx context.Context, req *driver.GetMachineSta
 	}
 
 	// if SrcAnDstCheckEnabled is false then check attribute on instance and return Uninitialized error if not matching.
+	// For instances with EFA interfaces, check per-interface since EFA interfaces don't support SourceDestCheck modification.
 	if providerSpec.SrcAndDstChecksEnabled != nil && !*providerSpec.SrcAndDstChecksEnabled {
-		if ptr.Deref(requiredInstance.SourceDestCheck, true) {
-			msg := fmt.Sprintf("VM %q associated with machine %q has SourceDestCheck=%t despite providerSpec.SrcAndDstChecksEnabled=%t",
-				ptr.Deref(requiredInstance.InstanceId, ""), req.Machine.Name, ptr.Deref(requiredInstance.SourceDestCheck, true), *providerSpec.SrcAndDstChecksEnabled)
+		srcDestCheckEnabled := false
+		for _, ni := range requiredInstance.NetworkInterfaces {
+			// Skip EFA and EFA-only interfaces as they don't support SourceDestCheck modification
+			if ptr.Deref(ni.InterfaceType, "") == string(ec2types.NetworkInterfaceTypeEfa) || ptr.Deref(ni.InterfaceType, "") == string(ec2types.NetworkInterfaceTypeEfaOnly) {
+				continue
+			}
+			if ni.SourceDestCheck != nil && *ni.SourceDestCheck {
+				srcDestCheckEnabled = true
+				break
+			}
+		}
+		if srcDestCheckEnabled {
+			msg := fmt.Sprintf("VM %q associated with machine %q has SourceDestCheck=true on a non-EFA interface despite providerSpec.SrcAndDstChecksEnabled=%t",
+				ptr.Deref(requiredInstance.InstanceId, ""), req.Machine.Name, *providerSpec.SrcAndDstChecksEnabled)
 			klog.Warning(msg)
 			return response, status.Error(codes.Uninitialized, msg)
 		}

--- a/pkg/aws/core.go
+++ b/pkg/aws/core.go
@@ -236,21 +236,13 @@ func (d *Driver) CreateMachine(ctx context.Context, req *driver.CreateMachineReq
 	// Set placement from providerSpec (first-class API), falling back to annotation
 	if providerSpec.Placement != nil {
 		placement := &ec2types.Placement{}
-		if providerSpec.Placement.GroupID != nil {
-			placement.GroupId = providerSpec.Placement.GroupID
-		}
 		if providerSpec.Placement.Tenancy != nil {
 			placement.Tenancy = ec2types.Tenancy(*providerSpec.Placement.Tenancy)
 		}
-		if providerSpec.Placement.HostID != nil {
-			placement.HostId = providerSpec.Placement.HostID
-		}
-		if providerSpec.Placement.PartitionNumber != nil {
-			placement.PartitionNumber = aws.Int32(int32(*providerSpec.Placement.PartitionNumber)) // #nosec: G115 -- partition number will not exceed int32 limits
-		}
-		if providerSpec.Placement.Affinity != nil {
-			placement.Affinity = providerSpec.Placement.Affinity
-		}
+		placement.GroupId = providerSpec.Placement.GroupID
+		placement.HostId = providerSpec.Placement.HostID
+		placement.PartitionNumber = providerSpec.Placement.PartitionNumber
+		placement.Affinity = providerSpec.Placement.Affinity
 		inputConfig.Placement = placement
 	} else {
 		placement, err := getPlacementObj(req)

--- a/pkg/aws/core.go
+++ b/pkg/aws/core.go
@@ -226,10 +226,23 @@ func (d *Driver) CreateMachine(ctx context.Context, req *driver.CreateMachineReq
 				CapacityReservationResourceGroupArn: providerSpec.CapacityReservationTarget.CapacityReservationResourceGroupArn,
 			},
 		}
-		if ptr.Deref(providerSpec.CapacityReservationTarget.IsMLCapacityBlock, false) {
-			inputConfig.InstanceMarketOptions = &ec2types.InstanceMarketOptionsRequest{
-				MarketType: ec2types.MarketTypeCapacityBlock,
-			}
+	}
+
+	// Set instance market options
+	if providerSpec.InstanceMarketOptions != nil {
+		inputConfig.InstanceMarketOptions = &ec2types.InstanceMarketOptionsRequest{
+			MarketType: ec2types.MarketType(providerSpec.InstanceMarketOptions.MarketType),
+		}
+	} else if providerSpec.SpotPrice != nil {
+		// Backward compatibility for deprecated SpotPrice field
+		inputConfig.InstanceMarketOptions = &ec2types.InstanceMarketOptionsRequest{
+			MarketType: ec2types.MarketTypeSpot,
+			SpotOptions: &ec2types.SpotMarketOptions{
+				SpotInstanceType: ec2types.SpotInstanceTypeOneTime,
+			},
+		}
+		if *providerSpec.SpotPrice != "" {
+			inputConfig.InstanceMarketOptions.SpotOptions.MaxPrice = providerSpec.SpotPrice
 		}
 	}
 
@@ -250,20 +263,6 @@ func (d *Driver) CreateMachine(ctx context.Context, req *driver.CreateMachineReq
 			return nil, status.Error(codes.Internal, err.Error())
 		} else if placement != nil {
 			inputConfig.Placement = placement
-		}
-	}
-
-	// Set spot price if it has been set
-	if providerSpec.SpotPrice != nil {
-		inputConfig.InstanceMarketOptions = &ec2types.InstanceMarketOptionsRequest{
-			MarketType: ec2types.MarketTypeSpot,
-			SpotOptions: &ec2types.SpotMarketOptions{
-				SpotInstanceType: ec2types.SpotInstanceTypeOneTime,
-			},
-		}
-
-		if *providerSpec.SpotPrice != "" {
-			inputConfig.InstanceMarketOptions.SpotOptions.MaxPrice = providerSpec.SpotPrice
 		}
 	}
 

--- a/pkg/aws/core.go
+++ b/pkg/aws/core.go
@@ -150,13 +150,8 @@ func (d *Driver) CreateMachine(ctx context.Context, req *driver.CreateMachineReq
 			spec.DeviceIndex = aws.Int32(int32(i)) // #nosec: G115 -- index will not exceed int32 limits
 		}
 
-		if netIf.NetworkCardIndex != nil {
-			spec.NetworkCardIndex = netIf.NetworkCardIndex
-		}
-
-		if netIf.InterfaceType != "" {
-			spec.InterfaceType = ptr.To(netIf.InterfaceType)
-		}
+		spec.NetworkCardIndex = netIf.NetworkCardIndex
+		spec.InterfaceType = netIf.InterfaceType
 
 		if netIf.DeleteOnTermination == nil {
 			spec.DeleteOnTermination = aws.Bool(true)

--- a/pkg/aws/core_util.go
+++ b/pkg/aws/core_util.go
@@ -61,22 +61,46 @@ func decodeProviderSpecAndSecret(machineClass *v1alpha1.MachineClass, secret *co
 	return providerSpec, nil
 }
 
-// disableSrcAndDestCheck disbales the SrcAndDestCheck for NAT instances
 func disableSrcAndDestCheck(ctx context.Context, svc interfaces.Ec2Client, instanceID *string) (err error) {
 	defer instrument.AwsAPIMetricRecorderFn(instanceDisableSourceDestCheckServiceLabel, &err)()
-	srcAndDstCheckEnabled := &ec2.ModifyInstanceAttributeInput{
-		InstanceId: instanceID,
-		SourceDestCheck: &ec2types.AttributeBooleanValue{
-			Value: ptr.To(false),
-		},
+
+	descInput := &ec2.DescribeInstancesInput{
+		InstanceIds: []string{ptr.Deref(instanceID, "")},
+	}
+	descOutput, descErr := svc.DescribeInstances(ctx, descInput)
+	if descErr != nil {
+		return descErr
+	}
+	if len(descOutput.Reservations) == 0 || len(descOutput.Reservations[0].Instances) == 0 {
+		return fmt.Errorf("no instance found for instanceID %s", ptr.Deref(instanceID, ""))
+	}
+	instance := descOutput.Reservations[0].Instances[0]
+	if len(instance.NetworkInterfaces) == 0 {
+		return fmt.Errorf("no network interfaces found for instanceID %s", ptr.Deref(instanceID, ""))
 	}
 
-	_, err = svc.ModifyInstanceAttribute(ctx, srcAndDstCheckEnabled)
-	if err != nil {
-		return err
+	var lastErr error
+	for _, ni := range instance.NetworkInterfaces {
+		// Skip EFA and EFA-only interfaces as they don't support source/dest check modification
+		if ptr.Deref(ni.InterfaceType, "") == string(ec2types.NetworkInterfaceTypeEfa) || ptr.Deref(ni.InterfaceType, "") == string(ec2types.NetworkInterfaceTypeEfaOnly) {
+			continue
+		}
+
+		input := &ec2.ModifyNetworkInterfaceAttributeInput{
+			NetworkInterfaceId: ni.NetworkInterfaceId,
+			SourceDestCheck: &ec2types.AttributeBooleanValue{
+				Value: ptr.To(false),
+			},
+		}
+		_, modErr := svc.ModifyNetworkInterfaceAttribute(ctx, input)
+		if modErr != nil {
+			klog.Errorf("Failed to disable Source/Destination check on interface %s for instance %s: %v", ptr.Deref(ni.NetworkInterfaceId, ""), ptr.Deref(instanceID, ""), modErr)
+			lastErr = modErr
+		} else {
+			klog.V(2).Infof("Successfully disabled Source/Destination check on interface %s for instance %s.", ptr.Deref(ni.NetworkInterfaceId, ""), ptr.Deref(instanceID, ""))
+		}
 	}
-	klog.V(2).Infof("Successfully disabled Source/Destination check on instance %s.", ptr.Deref(instanceID, ""))
-	return nil
+	return lastErr
 }
 
 func getMachineInstancesByTagsAndStatus(ctx context.Context, svc interfaces.Ec2Client, machineName string, providerSpecTags map[string]string) (instances []ec2types.Instance, err error) {

--- a/pkg/aws/core_util.go
+++ b/pkg/aws/core_util.go
@@ -61,6 +61,8 @@ func decodeProviderSpecAndSecret(machineClass *v1alpha1.MachineClass, secret *co
 	return providerSpec, nil
 }
 
+// disableSrcAndDestCheck disables the Source/Destination check on all non-EFA network interfaces of the instance.
+// EFA and efa-only interfaces are skipped because they do not support Source/Destination check modification.
 func disableSrcAndDestCheck(ctx context.Context, svc interfaces.Ec2Client, instanceID *string) (err error) {
 	defer instrument.AwsAPIMetricRecorderFn(instanceDisableSourceDestCheckServiceLabel, &err)()
 

--- a/pkg/aws/interfaces/ec2Client.go
+++ b/pkg/aws/interfaces/ec2Client.go
@@ -18,4 +18,5 @@ type Ec2Client interface {
 	DescribeImages(context.Context, *ec2.DescribeImagesInput, ...func(*ec2.Options)) (*ec2.DescribeImagesOutput, error)
 	RunInstances(context.Context, *ec2.RunInstancesInput, ...func(*ec2.Options)) (*ec2.RunInstancesOutput, error)
 	AssignIpv6Addresses(context.Context, *ec2.AssignIpv6AddressesInput, ...func(*ec2.Options)) (*ec2.AssignIpv6AddressesOutput, error)
+	ModifyNetworkInterfaceAttribute(context.Context, *ec2.ModifyNetworkInterfaceAttributeInput, ...func(*ec2.Options)) (*ec2.ModifyNetworkInterfaceAttributeOutput, error)
 }

--- a/pkg/mockclient/mockclient.go
+++ b/pkg/mockclient/mockclient.go
@@ -338,6 +338,12 @@ func (ms *MockEC2Client) StopInstances(_ context.Context, input *ec2.StopInstanc
 	}, nil
 }
 
+// ModifyNetworkInterfaceAttribute implements a mock modify network interface attribute method
+func (ms *MockEC2Client) ModifyNetworkInterfaceAttribute(_ context.Context, _ *ec2.ModifyNetworkInterfaceAttributeInput, _ ...func(*ec2.Options)) (*ec2.ModifyNetworkInterfaceAttributeOutput, error) {
+	// Always succeed for mock
+	return &ec2.ModifyNetworkInterfaceAttributeOutput{}, nil
+}
+
 // deepCopyTagList copies inTags list to outTags
 func deepCopyTagList(inTags []ec2types.Tag) []ec2types.Tag {
 	var outTags []ec2types.Tag


### PR DESCRIPTION
/area control-plane
/kind api-change
/platform aws

**What this PR does / why we need it**:

Adds support for EFA network interfaces, placement groups, and ML capacity blocks:
- Add InterfaceType, NetworkCardIndex, DeviceIndex, PrimaryIpv6 to AWSNetworkInterfaceSpec
- Add AWSPlacementSpec (groupId, tenancy, hostId, partitionNumber, affinity) to AWSProviderSpec
- Add InstanceMarketOptions.MarketType with currently valid values `spot`, `capacity-block`, `interruptible-capacity-reservation`
- Deprecate the overloaded SpotPrice in favour of using `InstanceMarketOptions.MarketType: spot` to explicitly specify using spot instances. Additionally, actual spot price feature is not used by extension-provider-aws as of today.
- Fix disableSrcAndDestCheck to skip EFA/efa-only interfaces (per-interface instead of per-instance)
- Fix GetMachineStatus to check SourceDestCheck per-interface (prevents Uninitialized loop on EFA instances)
- Spec-based placement with annotation fallback for backward compatibility
- Validation for new fields

**Which issue(s) this PR fixes**:
Fixes #246

**Special notes for your reviewer**:
- GetMachineStatus SourceDestCheck fix is critical: without it, EFA machines get stuck in Uninitialized state

**Locally tested cases**:

- [x] g4dn.12xlarge machine Running with EFA
- [x] p4d.24xlarge machines Running with 4 EFA NICs
- [x] Placement group applied via providerSpec
- [x] SourceDestCheck per-interface (no Uninitialized loop)
- [x] Validation: invalid interfaceType rejected
- [x] Validation: negative deviceIndex rejected
- [x] Validation: negative networkCardIndex rejected
- [x] Validation: isMLCapacityBlock without ID rejected
- [x] Validation: invalid placement tenancy rejected
- [x] Validation: hostId without tenancy host rejected

**Release note**:

```feature user
Add support for EFA network interfaces (InterfaceType, NetworkCardIndex, DeviceIndex) in EC2 instance creation
```

```feature user
Add placement group, tenancy, and dedicated host configuration support via providerSpec
```

```feature user
Add `InstanceMarketOptions.MarketType` to specify market-type options such as `spot`, `capacity-block` (ML capacity block reservations), etc.
```

```noteworthy user
`SpotPrice` is now deprecated, and will be removed in a future release. Please use `InstanceMarketOptions.MarketType: spot` instead.
```

```bugfix user
Fix SourceDestCheck validation for EFA instances causing machines to get stuck in Uninitialized state
```