### PR TITLE
Map `InsufficientFreeAddressesInSubnet` AWS error to `ResourceExhausted`

### DIFF
--- a/pkg/aws/errors/codes.go
+++ b/pkg/aws/errors/codes.go
@@ -49,6 +49,10 @@ const (
 	// You can try to provision a different volume type, EBS volume in a different availability zone, or you can wait for additional capacity to become available.
 	InsufficientVolumeCapacity = "InsufficientVolumeCapacity"
 
+	// InsufficientFreeAddressesInSubnet is returned when the specified subnet does not contain enough free private IP addresses
+	// to fulfill your request.
+	InsufficientFreeAddressesInSubnet = "InsufficientFreeAddressesInSubnet"
+
 	// RouteLimitExceeded is returned when you've reached the limit on the number of routes that you can add to a route table.
 	RouteLimitExceeded = "RouteLimitExceeded"
 

--- a/pkg/aws/errors/utils.go
+++ b/pkg/aws/errors/utils.go
@@ -20,6 +20,7 @@ func GetMCMErrorCodeForCreateMachine(err error) codes.Code {
 			InsufficientAddressCapacity,
 			InsufficientInstanceCapacity,
 			InsufficientVolumeCapacity,
+			InsufficientFreeAddressesInSubnet,
 			InstanceLimitExceeded,
 			VcpuLimitExceeded,
 			VolumeLimitExceeded,

--- a/pkg/aws/errors/utils_test.go
+++ b/pkg/aws/errors/utils_test.go
@@ -23,6 +23,7 @@ func TestGetMCMErrorCodeForCreateMachine(t *testing.T) {
 		{inputError: &smithy.GenericAPIError{Code: "InsufficientAddressCapacity"}, expectedCode: codes.ResourceExhausted},
 		{inputError: &smithy.GenericAPIError{Code: "InsufficientInstanceCapacity"}, expectedCode: codes.ResourceExhausted},
 		{inputError: &smithy.GenericAPIError{Code: "InsufficientVolumeCapacity"}, expectedCode: codes.ResourceExhausted},
+		{inputError: &smithy.GenericAPIError{Code: "InsufficientFreeAddressesInSubnet"}, expectedCode: codes.ResourceExhausted},
 		{inputError: &smithy.GenericAPIError{Code: "InstanceLimitExceeded"}, expectedCode: codes.ResourceExhausted},
 		{inputError: &smithy.GenericAPIError{Code: "VcpuLimitExceeded"}, expectedCode: codes.ResourceExhausted},
 		{inputError: &smithy.GenericAPIError{Code: "VolumeLimitExceeded"}, expectedCode: codes.ResourceExhausted},


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
This PR maps the `InsufficientFreeAddressesInSubnet` error returned by AWS during VM creation with unavailable addresses to the `ResourceExhausted` error code.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
InsufficientFreeAddressesInSubnet error is now mapped to ResourceExhausted error code
```
