### PR TITLE
Honor machine.Spec.MachineConfiguration.MachineCreationTimeout

### DIFF
--- a/pkg/aws/core.go
+++ b/pkg/aws/core.go
@@ -54,7 +54,7 @@ const (
 	awsPlacement     = "machine.sapcloud.io/awsPlacement"
 )
 
-var maxElapsedTimeInBackoff = 5 * time.Minute
+var defaultMaxElapsedTimeInBackoff = 5 * time.Minute
 
 // NewAWSDriver returns an empty AWSDriver object
 func NewAWSDriver(cpi cpi.ClientProviderInterface) driver.Driver {
@@ -303,6 +303,10 @@ func (d *Driver) CreateMachine(ctx context.Context, req *driver.CreateMachineReq
 		return nil, status.Error(codes.NotFound, fmt.Sprintf("instance with instanceID %s not found", instanceID))
 	}
 
+	maxElapsedTimeInBackoff := defaultMaxElapsedTimeInBackoff
+	if machine.Spec.MachineConfiguration != nil && machine.Spec.MachineCreationTimeout != nil {
+		maxElapsedTimeInBackoff = machine.Spec.MachineCreationTimeout.Duration
+	}
 	instance, err := retryWithExponentialBackOff(operation, maxElapsedTimeInBackoff)
 	if err != nil {
 		return nil, status.Error(codes.Internal, fmt.Sprintf("creation of VM %q failed, timed out waiting for eventual consistency. Multiple VMs backing machine obj might spawn, they will be orphan collected", providerID))

--- a/pkg/aws/core_test.go
+++ b/pkg/aws/core_test.go
@@ -71,12 +71,12 @@ var _ = Describe("MachineServer", func() {
 				var temp time.Duration
 
 				if data.setup.maxElapsedTimeForRetry != 0 {
-					temp = maxElapsedTimeInBackoff
-					maxElapsedTimeInBackoff = data.setup.maxElapsedTimeForRetry
+					temp = defaultMaxElapsedTimeInBackoff
+					defaultMaxElapsedTimeInBackoff = data.setup.maxElapsedTimeForRetry
 				}
 				response, err := md.CreateMachine(ctx, data.action.machineRequest)
 
-				maxElapsedTimeInBackoff = temp
+				defaultMaxElapsedTimeInBackoff = temp
 
 				if data.expect.errToHaveOccurred {
 					Expect(err).To(HaveOccurred())

--- a/pkg/aws/util.go
+++ b/pkg/aws/util.go
@@ -111,8 +111,8 @@ func getInt32PtrForString(s string) *int32 {
 	return ptr.To(int32(num))
 }
 
-func retryWithExponentialBackOff(operation backoff.OperationWithData[*ec2types.Instance], _ time.Duration) (*ec2types.Instance, error) {
+func retryWithExponentialBackOff(operation backoff.OperationWithData[*ec2types.Instance], maxElapsedTime time.Duration) (*ec2types.Instance, error) {
 	expBackOffObj := backoff.NewExponentialBackOff()
-	expBackOffObj.MaxElapsedTime = maxElapsedTimeInBackoff
+	expBackOffObj.MaxElapsedTime = maxElapsedTime
 	return backoff.RetryWithData(operation, expBackOffObj)
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
See https://github.com/gardener/dependency-watchdog/issues/201
and https://github.com/gardener/machine-controller-manager/issues/1098 for background

Providers are not honoring real Machine creation timeout but have hardcoded values to a few minutes. This causes repeated `CrashLoopbackoff` failures when provider is slow.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Honor machine.Spec.MachineConfiguration.MachineCreationTimeout for AWS machine creation instead of using a hardcoded timeout
```
